### PR TITLE
[HOTFIX][BE] Fix git command are not load properly 

### DIFF
--- a/app/Helpers/AppHelper.php
+++ b/app/Helpers/AppHelper.php
@@ -76,6 +76,33 @@ class AppHelper
         ftp_close($ftp_conn);
     }
 
+    function getGitCommitHash()
+    {
+        $gitSourcePath = base_path('.git/');
+
+        if (!file_exists($gitSourcePath)) {
+            return null;
+        }
+
+        $headFile = $gitSourcePath.'HEAD';
+        $head = trim(file_get_contents($headFile));
+
+        if (strpos($head, 'ref: ') === 0) {
+            $ref = substr($head, 5);
+            $commitHashFile = $gitSourcePath . $ref;
+
+            if (!file_exists($commitHashFile)) {
+                return null;
+            }
+
+            $hash = trim(file_get_contents($commitHashFile));
+        } else {
+            $hash = $head;
+        }
+
+        return substr($hash, 0, 7);
+    }
+
     function get_guid() {
         if (function_exists('com_create_guid') === true) {
             return trim(com_create_guid(), '{}');

--- a/app/Http/Controllers/Api/versionController.php
+++ b/app/Http/Controllers/Api/versionController.php
@@ -88,7 +88,7 @@ class versionController extends Controller {
             $appMajorVersionBE = 3;
             $appMinorVersionBE = 2;
             $appPatchVersionBE = 6;
-            $appGitVersionBE = trim(exec('git log --pretty="%h" -n1 HEAD'));
+            $appGitVersionBE = appHelper::instance()->getGitCommitHash();
             $appServicesReferrerBE = "BE";
             $validateBE = false;
             $validateFE = false;


### PR DESCRIPTION
- Switch to other method to read git head revision, instead by using exec(). Read the HEAD file directly to determine hash revision