### PR TITLE
[HOTFIX][BE] Fix total pages for PDF are not counted on FE services

### DIFF
--- a/app/Console/Commands/DailyReport.php
+++ b/app/Console/Commands/DailyReport.php
@@ -49,7 +49,7 @@ class DailyReport extends Command
                                         ->update(['isReport' => true]);
             }
             $compTotalErr = compressModel::where('procStartAt', '>=', $currentTime)
-                                        ->where('result', false)
+                                        ->where('result', '=', false)
                                         ->where('isReport', '=', false)
                                         ->count();
             if ($compTotalErr > 0) {
@@ -69,12 +69,12 @@ class DailyReport extends Command
                                         ->update(['isReport' => true]);
             }
             $cnvTotalErr = cnvModel::where('procStartAt', '>=', $currentTime)
-                                        ->where('result', false)
+                                        ->where('result', '=', false)
                                         ->where('isReport', '=', false)
                                         ->count();
             if ($cnvTotalErr > 0) {
                 cnvModel::where('procStartAt', '>=', $currentTime)
-                                        ->where('result', false)
+                                        ->where('result', '=', false)
                                         ->where('isReport', '=', false)
                                         ->update(['isReport' => true]);
             }
@@ -89,12 +89,12 @@ class DailyReport extends Command
                                         ->update(['isReport' => true]);
             }
             $htmlTotalErr = htmlModel::where('procStartAt', '>=', $currentTime)
-                                        ->where('result', false)
+                                        ->where('result', '=', false)
                                         ->where('isReport', '=', false)
                                         ->count();
             if ($htmlTotalErr > 0) {
                 htmlModel::where('procStartAt', '>=', $currentTime)
-                                        ->where('result', false)
+                                        ->where('result', '=', false)
                                         ->where('isReport', '=', false)
                                         ->update(['isReport' => true]);
             }
@@ -109,12 +109,12 @@ class DailyReport extends Command
                                         ->update(['isReport' => true]);
             }
             $mergeTotalErr = mergeModel::where('procStartAt', '>=', $currentTime)
-                                        ->where('result', false)
+                                        ->where('result', '=', false)
                                         ->where('isReport', '=', false)
                                         ->count();
             if ($mergeTotalErr > 0) {
                 mergeModel::where('procStartAt', '>=', $currentTime)
-                                        ->where('result', false)
+                                        ->where('result', '=', false)
                                         ->where('isReport', '=', false)
                                         ->update(['isReport' => true]);
             }
@@ -129,12 +129,12 @@ class DailyReport extends Command
                                         ->update(['isReport' => true]);
             }
             $splitTotalErr = splitModel::where('procStartAt', '>=', $currentTime)
-                                        ->where('result', false)
+                                        ->where('result', '=', false)
                                         ->where('isReport', '=', false)
                                         ->count();
             if ($splitTotalErr > 0) {
                 splitModel::where('procStartAt', '>=', $currentTime)
-                                        ->where('result', false)
+                                        ->where('result', '=', false)
                                         ->where('isReport', '=', false)
                                         ->update(['isReport' => true]);
             }
@@ -149,12 +149,12 @@ class DailyReport extends Command
                                         ->update(['isReport' => true]);
             }
             $watermarkTotalErr = watermarkModel::where('procStartAt', '>=', $currentTime)
-                                        ->where('result', false)
+                                        ->where('result', '=', false)
                                         ->where('isReport', '=', false)
                                         ->count();
             if ($watermarkTotalErr > 0) {
                 watermarkModel::where('procStartAt', '>=', $currentTime)
-                                        ->where('result', false)
+                                        ->where('result', '=', false)
                                         ->where('isReport', '=', false)
                                         ->update(['isReport' => true]);
             }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -48,7 +48,7 @@ class Kernel extends ConsoleKernel
 					]);
                 DB::table('jobLogs')->insert([
                     'jobsName' => 'cache:clear',
-                    'jobsEnv' => 'production',
+                    'jobsEnv' => 'production-be',
                     'jobsRuntime' => 'weekly',
                     'jobsResult' => false,
                     'processId' => $cacheClearGUID,
@@ -99,7 +99,7 @@ class Kernel extends ConsoleKernel
 					]);
                 DB::table('jobLogs')->insert([
                     'jobsName' => 'optimize:clear',
-                    'jobsEnv' => 'production',
+                    'jobsEnv' => 'production-be',
                     'jobsRuntime' => 'weekly',
                     'jobsResult' => false,
                     'processId' => $optimizeClearGUID,
@@ -150,7 +150,7 @@ class Kernel extends ConsoleKernel
 					]);
                 DB::table('jobLogs')->insert([
                     'jobsName' => 'view:clear',
-                    'jobsEnv' => 'production',
+                    'jobsEnv' => 'production-be',
                     'jobsRuntime' => 'weekly',
                     'jobsResult' => false,
                     'processId' => $viewClearGUID,
@@ -201,7 +201,7 @@ class Kernel extends ConsoleKernel
 					]);
                 DB::table('jobLogs')->insert([
                     'jobsName' => 'view:cache',
-                    'jobsEnv' => 'production',
+                    'jobsEnv' => 'production-be',
                     'jobsRuntime' => 'weekly',
                     'jobsResult' => false,
                     'processId' => $viewCacheGUID,
@@ -252,7 +252,7 @@ class Kernel extends ConsoleKernel
 					]);
                 DB::table('jobLogs')->insert([
                     'jobsName' => 'hana:clear-storage',
-                    'jobsEnv' => 'production',
+                    'jobsEnv' => 'production-be',
                     'jobsRuntime' => 'hourly',
                     'jobsResult' => false,
                     'processId' => $hanaClearGUID,
@@ -303,7 +303,7 @@ class Kernel extends ConsoleKernel
 					]);
                 DB::table('jobLogs')->insert([
                     'jobsName' => 'hana:daily-report',
-                    'jobsEnv' => 'production',
+                    'jobsEnv' => 'production-be',
                     'jobsRuntime' => 'Daily at 19.00',
                     'jobsResult' => false,
                     'processId' => $hanaReportGUID,

--- a/app/Http/Controllers/Api/Core/htmltopdfController.php
+++ b/app/Http/Controllers/Api/Core/htmltopdfController.php
@@ -27,7 +27,7 @@ class htmltopdfController extends Controller
         $validator = Validator::make($request->all(),[
 		    'urlToPDF' => 'required',
             'urlMarginValue' => ['required', 'numeric'],
-            'urlSizeValue' => ['required', 'in:A3,A4,A5,Auto,Letter'],
+            'urlSizeValue' => ['required', 'in:A3,A4,A5,Letter'],
             'urlPageOrientationValue' => ['required', 'in:landscape,portrait'],
             'urlSinglePage' => ['required', 'in:true,false']
 	    ]);

--- a/app/Http/Controllers/Api/Core/splitController.php
+++ b/app/Http/Controllers/Api/Core/splitController.php
@@ -128,227 +128,243 @@ class splitController extends Controller
                                 $customPage = $customInputPage;
                             }
                             if ($fromPage != '') {
-                                $pdfTotalPages = AppHelper::instance()->count($newFilePath);
-                                if ($toPage > $pdfTotalPages) {
-                                    $end = Carbon::parse(AppHelper::instance()->getCurrentTimeZone());
-                                    $duration = $end->diff($startProc);
-                                    try {
-                                        DB::table('appLogs')->insert([
-                                            'processId' => $uuid,
-                                            'errReason' => 'Last page has more page than total PDF page ! (total page: '.$pdfTotalPages.')',
-                                            'errStatus' => null
-                                        ]);
-                                        DB::table('pdfSplit')->insert([
-                                            'fileName' => $currentFileName,
-                                            'fileSize' => $newFileSize,
-                                            'fromPage' => $fromPage,
-                                            'toPage' => $toPage,
-                                            'customPage' => null,
-                                            'fixedPage' => null,
-                                            'fixedPageRange' => null,
-                                            'mergePDF' => $mergeDBpdf,
-                                            'action' => $action,
-                                            'result' => false,
-                                            'isBatch' => $batchValue,
-                                            'processId' => $uuid,
-                                            'batchId' => $batchId,
-                                            'procStartAt' => $startProc,
-                                            'procEndAt' => AppHelper::instance()->getCurrentTimeZone(),
-                                            'procDuration' =>  $duration->s.' seconds'
-                                        ]);
-                                        NotificationHelper::Instance()->sendErrNotify($currentFileName, $fileSize, $uuid, 'FAIL', 'split', 'PDF split failed!', 'Last page has more page than total PDF page ! (total page: '.$pdfTotalPages.')');
-                                        return $this->returnCoreMessage(
-                                            200,
-                                            'PDF split failed!',
-                                            $currentFileName,
-                                            null,
-                                            'split',
-                                            $uuid,
-                                            $fileSize,
-                                            null,
-                                            null,
-                                            'Last page has more page than total PDF page ! (total page: '.$pdfTotalPages.')'
-                                        );
-                                    } catch (QueryException $ex) {
-                                        NotificationHelper::Instance()->sendErrNotify($currentFileName, $fileSize, $uuid, 'FAIL', 'split', 'Database connection error !',$ex->getMessage());
-                                        return $this->returnCoreMessage(
-                                            200,
-                                            'Database connection error !',
-                                            $currentFileName,
-                                            null,
-                                            'split',
-                                            $uuid,
-                                            $fileSize,
-                                            null,
-                                            null,
-                                            $ex->getMessage()
-                                        );
-                                    } catch (\Exception $e) {
-                                        NotificationHelper::Instance()->sendErrNotify($currentFileName, $fileSize, $uuid, 'FAIL', 'split', 'Eloquent transaction error !', $e->getMessage());
-                                        return $this->returnCoreMessage(
-                                            200,
-                                            'Eloquent transaction error !',
-                                            $currentFileName,
-                                            null,
-                                            'split',
-                                            $uuid,
-                                            $fileSize,
-                                            null,
-                                            null,
-                                            $e->getMessage()
-                                        );
-                                    }
-                                } else if ($fromPage > $pdfTotalPages) {
-                                    $end = Carbon::parse(AppHelper::instance()->getCurrentTimeZone());
-                                    $duration = $end->diff($startProc);
-                                    try {
-                                        DB::table('appLogs')->insert([
-                                            'processId' => $uuid,
-                                            'errReason' => 'First page has more page than total PDF page ! (total page: '.$pdfTotalPages.')',
-                                            'errStatus' => null
-                                        ]);
-                                        DB::table('pdfSplit')->insert([
-                                            'fileName' => $currentFileName,
-                                            'fileSize' => $newFileSize,
-                                            'fromPage' => $fromPage,
-                                            'toPage' => $toPage,
-                                            'customPage' => null,
-                                            'fixedPage' => null,
-                                            'fixedPageRange' => null,
-                                            'mergePDF' => $mergeDBpdf,
-                                            'action' => $action,
-                                            'result' => false,
-                                            'isBatch' => $batchValue,
-                                            'processId' => $uuid,
-                                            'batchId' => $batchId,
-                                            'procStartAt' => $startProc,
-                                            'procEndAt' => AppHelper::instance()->getCurrentTimeZone(),
-                                            'procDuration' =>  $duration->s.' seconds'
-                                        ]);
-                                        NotificationHelper::Instance()->sendErrNotify($currentFileName, $newFileSize, $uuid, 'FAIL', 'split', 'PDF split failed!', 'First page has more page than total PDF page ! (total page: '.$pdfTotalPages.')');
-                                        return $this->returnCoreMessage(
-                                            200,
-                                            'PDF split failed!',
-                                            $currentFileName,
-                                            null,
-                                            'split',
-                                            $uuid,
-                                            $fileSize,
-                                            null,
-                                            null,
-                                            'First page has more page than total PDF page ! (total page: '.$pdfTotalPages.')'
-                                        );
-                                    } catch (QueryException $ex) {
-                                        NotificationHelper::Instance()->sendErrNotify($currentFileName, $fileSize, $uuid, 'FAIL', 'split', 'Database connection error !',$ex->getMessage());
-                                        return $this->returnCoreMessage(
-                                            200,
-                                            'Database connection error !',
-                                            $currentFileName,
-                                            null,
-                                            'split',
-                                            $uuid,
-                                            $fileSize,
-                                            null,
-                                            null,
-                                            $ex->getMessage()
-                                        );
-                                    } catch (\Exception $e) {
-                                        NotificationHelper::Instance()->sendErrNotify($currentFileName, $fileSize, $uuid, 'FAIL', 'split', 'Eloquent transaction error !', $e->getMessage());
-                                        return $this->returnCoreMessage(
-                                            200,
-                                            'Eloquent transaction error !',
-                                            $currentFileName,
-                                            null,
-                                            'split',
-                                            $uuid,
-                                            $fileSize,
-                                            null,
-                                            null,
-                                            $e->getMessage()
-                                        );
-                                    }
-                                } else if ($fromPage > $toPage) {
-                                    $end = Carbon::parse(AppHelper::instance()->getCurrentTimeZone());
-                                    $duration = $end->diff($startProc);
-                                    try {
-                                        DB::table('appLogs')->insert([
-                                            'processId' => $uuid,
-                                            'errReason' => 'First Page has more page than last page ! (total page: '.$pdfTotalPages.')',
-                                            'errStatus' => null
-                                        ]);
-                                        DB::table('pdfSplit')->insert([
-                                            'fileName' => $currentFileName,
-                                            'fileSize' => $newFileSize,
-                                            'fromPage' => $fromPage,
-                                            'toPage' => $toPage,
-                                            'customPage' => null,
-                                            'fixedPage' => null,
-                                            'fixedPageRange' => null,
-                                            'mergePDF' => $mergeDBpdf,
-                                            'action' => $action,
-                                            'result' => false,
-                                            'isBatch' => $batchValue,
-                                            'processId' => $uuid,
-                                            'batchId' => $batchId,
-                                            'procStartAt' => $startProc,
-                                            'procEndAt' => AppHelper::instance()->getCurrentTimeZone(),
-                                            'procDuration' =>  $duration->s.' seconds'
-                                        ]);
-                                        NotificationHelper::Instance()->sendErrNotify($currentFileName, $newFileSize, $uuid, 'FAIL', 'split', 'PDF split failed!', 'First Page has more page than last page ! (total page: '.$pdfTotalPages.')');
-                                        return $this->returnCoreMessage(
-                                            200,
-                                            'PDF split failed!',
-                                            $currentFileName,
-                                            null,
-                                            'split',
-                                            $uuid,
-                                            $fileSize,
-                                            null,
-                                            null,
-                                            'First Page has more page than last page ! (total page: '.$pdfTotalPages.')'
-                                        );
-                                    } catch (QueryException $ex) {
-                                        NotificationHelper::Instance()->sendErrNotify($currentFileName, $fileSize, $uuid, 'FAIL', 'split', 'Database connection error !',$ex->getMessage());
-                                        return $this->returnCoreMessage(
-                                            200,
-                                            'Database connection error !',
-                                            $currentFileName,
-                                            null,
-                                            'split',
-                                            $uuid,
-                                            $fileSize,
-                                            null,
-                                            null,
-                                            $ex->getMessage()
-                                        );
-                                    } catch (\Exception $e) {
-                                        NotificationHelper::Instance()->sendErrNotify($currentFileName, $fileSize, $uuid, 'FAIL', 'split', 'Eloquent transaction error !', $e->getMessage());
-                                        return $this->returnCoreMessage(
-                                            200,
-                                            'Eloquent transaction error !',
-                                            $currentFileName,
-                                            null,
-                                            'split',
-                                            $uuid,
-                                            $fileSize,
-                                            null,
-                                            null,
-                                            $e->getMessage()
-                                        );
-                                    }
-                                } else {
-                                    if ($mergeDBpdf == "true") {
-                                        $fixedPageRanges = $fromPage.'-'.$toPage;
-                                    } else if ($mergeDBpdf == "false") {
-                                        $pdfStartPages = $fromPage;
-                                        $pdfTotalPages = $toPage;
-                                        while($pdfStartPages <= intval($pdfTotalPages))
-                                        {
-                                            $pdfArrayPages[] = $pdfStartPages;
-                                            $pdfStartPages += 1;
+                                try {
+                                    $pdfTotalPages = AppHelper::instance()->count($newFilePath);
+                                    if ($toPage > $pdfTotalPages) {
+                                        $end = Carbon::parse(AppHelper::instance()->getCurrentTimeZone());
+                                        $duration = $end->diff($startProc);
+                                        try {
+                                            DB::table('appLogs')->insert([
+                                                'processId' => $uuid,
+                                                'errReason' => 'Last page has more page than total PDF page ! (total page: '.$pdfTotalPages.')',
+                                                'errStatus' => null
+                                            ]);
+                                            DB::table('pdfSplit')->insert([
+                                                'fileName' => $currentFileName,
+                                                'fileSize' => $newFileSize,
+                                                'fromPage' => $fromPage,
+                                                'toPage' => $toPage,
+                                                'customPage' => null,
+                                                'fixedPage' => null,
+                                                'fixedPageRange' => null,
+                                                'mergePDF' => $mergeDBpdf,
+                                                'action' => $action,
+                                                'result' => false,
+                                                'isBatch' => $batchValue,
+                                                'processId' => $uuid,
+                                                'batchId' => $batchId,
+                                                'procStartAt' => $startProc,
+                                                'procEndAt' => AppHelper::instance()->getCurrentTimeZone(),
+                                                'procDuration' =>  $duration->s.' seconds'
+                                            ]);
+                                            NotificationHelper::Instance()->sendErrNotify($currentFileName, $fileSize, $uuid, 'FAIL', 'split', 'PDF split failed!', 'Last page has more page than total PDF page ! (total page: '.$pdfTotalPages.')');
+                                            return $this->returnCoreMessage(
+                                                200,
+                                                'PDF split failed!',
+                                                $currentFileName,
+                                                null,
+                                                'split',
+                                                $uuid,
+                                                $fileSize,
+                                                null,
+                                                null,
+                                                'Last page has more page than total PDF page ! (total page: '.$pdfTotalPages.')'
+                                            );
+                                        } catch (QueryException $ex) {
+                                            NotificationHelper::Instance()->sendErrNotify($currentFileName, $fileSize, $uuid, 'FAIL', 'split', 'Database connection error !',$ex->getMessage());
+                                            return $this->returnCoreMessage(
+                                                200,
+                                                'Database connection error !',
+                                                $currentFileName,
+                                                null,
+                                                'split',
+                                                $uuid,
+                                                $fileSize,
+                                                null,
+                                                null,
+                                                $ex->getMessage()
+                                            );
+                                        } catch (\Exception $e) {
+                                            NotificationHelper::Instance()->sendErrNotify($currentFileName, $fileSize, $uuid, 'FAIL', 'split', 'Eloquent transaction error !', $e->getMessage());
+                                            return $this->returnCoreMessage(
+                                                200,
+                                                'Eloquent transaction error !',
+                                                $currentFileName,
+                                                null,
+                                                'split',
+                                                $uuid,
+                                                $fileSize,
+                                                null,
+                                                null,
+                                                $e->getMessage()
+                                            );
                                         }
-                                        $fixedPageRanges = implode(', ', $pdfArrayPages);
+                                    } else if ($fromPage > $pdfTotalPages) {
+                                        $end = Carbon::parse(AppHelper::instance()->getCurrentTimeZone());
+                                        $duration = $end->diff($startProc);
+                                        try {
+                                            DB::table('appLogs')->insert([
+                                                'processId' => $uuid,
+                                                'errReason' => 'First page has more page than total PDF page ! (total page: '.$pdfTotalPages.')',
+                                                'errStatus' => null
+                                            ]);
+                                            DB::table('pdfSplit')->insert([
+                                                'fileName' => $currentFileName,
+                                                'fileSize' => $newFileSize,
+                                                'fromPage' => $fromPage,
+                                                'toPage' => $toPage,
+                                                'customPage' => null,
+                                                'fixedPage' => null,
+                                                'fixedPageRange' => null,
+                                                'mergePDF' => $mergeDBpdf,
+                                                'action' => $action,
+                                                'result' => false,
+                                                'isBatch' => $batchValue,
+                                                'processId' => $uuid,
+                                                'batchId' => $batchId,
+                                                'procStartAt' => $startProc,
+                                                'procEndAt' => AppHelper::instance()->getCurrentTimeZone(),
+                                                'procDuration' =>  $duration->s.' seconds'
+                                            ]);
+                                            NotificationHelper::Instance()->sendErrNotify($currentFileName, $newFileSize, $uuid, 'FAIL', 'split', 'PDF split failed!', 'First page has more page than total PDF page ! (total page: '.$pdfTotalPages.')');
+                                            return $this->returnCoreMessage(
+                                                200,
+                                                'PDF split failed!',
+                                                $currentFileName,
+                                                null,
+                                                'split',
+                                                $uuid,
+                                                $fileSize,
+                                                null,
+                                                null,
+                                                'First page has more page than total PDF page ! (total page: '.$pdfTotalPages.')'
+                                            );
+                                        } catch (QueryException $ex) {
+                                            NotificationHelper::Instance()->sendErrNotify($currentFileName, $fileSize, $uuid, 'FAIL', 'split', 'Database connection error !',$ex->getMessage());
+                                            return $this->returnCoreMessage(
+                                                200,
+                                                'Database connection error !',
+                                                $currentFileName,
+                                                null,
+                                                'split',
+                                                $uuid,
+                                                $fileSize,
+                                                null,
+                                                null,
+                                                $ex->getMessage()
+                                            );
+                                        } catch (\Exception $e) {
+                                            NotificationHelper::Instance()->sendErrNotify($currentFileName, $fileSize, $uuid, 'FAIL', 'split', 'Eloquent transaction error !', $e->getMessage());
+                                            return $this->returnCoreMessage(
+                                                200,
+                                                'Eloquent transaction error !',
+                                                $currentFileName,
+                                                null,
+                                                'split',
+                                                $uuid,
+                                                $fileSize,
+                                                null,
+                                                null,
+                                                $e->getMessage()
+                                            );
+                                        }
+                                    } else if ($fromPage > $toPage) {
+                                        $end = Carbon::parse(AppHelper::instance()->getCurrentTimeZone());
+                                        $duration = $end->diff($startProc);
+                                        try {
+                                            DB::table('appLogs')->insert([
+                                                'processId' => $uuid,
+                                                'errReason' => 'First Page has more page than last page ! (total page: '.$pdfTotalPages.')',
+                                                'errStatus' => null
+                                            ]);
+                                            DB::table('pdfSplit')->insert([
+                                                'fileName' => $currentFileName,
+                                                'fileSize' => $newFileSize,
+                                                'fromPage' => $fromPage,
+                                                'toPage' => $toPage,
+                                                'customPage' => null,
+                                                'fixedPage' => null,
+                                                'fixedPageRange' => null,
+                                                'mergePDF' => $mergeDBpdf,
+                                                'action' => $action,
+                                                'result' => false,
+                                                'isBatch' => $batchValue,
+                                                'processId' => $uuid,
+                                                'batchId' => $batchId,
+                                                'procStartAt' => $startProc,
+                                                'procEndAt' => AppHelper::instance()->getCurrentTimeZone(),
+                                                'procDuration' =>  $duration->s.' seconds'
+                                            ]);
+                                            NotificationHelper::Instance()->sendErrNotify($currentFileName, $newFileSize, $uuid, 'FAIL', 'split', 'PDF split failed!', 'First Page has more page than last page ! (total page: '.$pdfTotalPages.')');
+                                            return $this->returnCoreMessage(
+                                                200,
+                                                'PDF split failed!',
+                                                $currentFileName,
+                                                null,
+                                                'split',
+                                                $uuid,
+                                                $fileSize,
+                                                null,
+                                                null,
+                                                'First Page has more page than last page ! (total page: '.$pdfTotalPages.')'
+                                            );
+                                        } catch (QueryException $ex) {
+                                            NotificationHelper::Instance()->sendErrNotify($currentFileName, $fileSize, $uuid, 'FAIL', 'split', 'Database connection error !',$ex->getMessage());
+                                            return $this->returnCoreMessage(
+                                                200,
+                                                'Database connection error !',
+                                                $currentFileName,
+                                                null,
+                                                'split',
+                                                $uuid,
+                                                $fileSize,
+                                                null,
+                                                null,
+                                                $ex->getMessage()
+                                            );
+                                        } catch (\Exception $e) {
+                                            NotificationHelper::Instance()->sendErrNotify($currentFileName, $fileSize, $uuid, 'FAIL', 'split', 'Eloquent transaction error !', $e->getMessage());
+                                            return $this->returnCoreMessage(
+                                                200,
+                                                'Eloquent transaction error !',
+                                                $currentFileName,
+                                                null,
+                                                'split',
+                                                $uuid,
+                                                $fileSize,
+                                                null,
+                                                null,
+                                                $e->getMessage()
+                                            );
+                                        }
+                                    } else {
+                                        if ($mergeDBpdf == "true") {
+                                            $fixedPageRanges = $fromPage.'-'.$toPage;
+                                        } else if ($mergeDBpdf == "false") {
+                                            $pdfStartPages = $fromPage;
+                                            $pdfTotalPages = $toPage;
+                                            while($pdfStartPages <= intval($pdfTotalPages))
+                                            {
+                                                $pdfArrayPages[] = $pdfStartPages;
+                                                $pdfStartPages += 1;
+                                            }
+                                            $fixedPageRanges = implode(', ', $pdfArrayPages);
+                                        }
                                     }
+                                } catch (\Exception $e) {
+                                    NotificationHelper::Instance()->sendErrNotify($currentFileName, $fileSize, $uuid, 'FAIL', 'split', 'Failed to count total PDF pages from '.$currentFileName, $e->getMessage());
+                                    return $this->returnCoreMessage(
+                                        200,
+                                        'Failed to count total PDF pages from '.$currentFileName,
+                                        $currentFileName,
+                                        $newFilePath,
+                                        'split',
+                                        $uuid,
+                                        $fileSize,
+                                        null,
+                                        null,
+                                        $e->getMessage()
+                                    );
                                 }
                             } else {
                                 $fixedPageRanges = $customPage;

--- a/app/Http/Controllers/Api/Data/notifyLogController.php
+++ b/app/Http/Controllers/Api/Data/notifyLogController.php
@@ -180,6 +180,7 @@ class notifyLogController extends Controller
     {
         $validator = Validator::make($request->all(), [
             'logCount' => 'required|int',
+            'logResult' => ['required', 'in:true,false'],
             'logType' =>  ['required', 'in:access,jobs,notify,compress,convert,html,merge,split,watermark'],
             'logOrder' => ['required', 'in:asc,desc']
         ]);
@@ -197,29 +198,30 @@ class notifyLogController extends Controller
             );
         }
         $logCount = $request->input('logCount');
+        $logResult = $request->input('logResult');
         $logModel = $request->input('logType');
         $logOrder = $request->input('logOrder');
         try {
             if ($logModel == 'access') {
-                $datalog = accessLogsModel::take($logCount)->get();
+                $datalog = accessLogsModel::orderBy('procStartAt', $logOrder)->take($logCount)->get();
             } else if ($logModel == 'jobs') {
-                $datalog = jobLogsModel::take($logCount)->get();
+                $datalog = jobLogsModel::orderBy('procStartAt', $logOrder)->take($logCount)->get();
             } else if ($logModel == 'notify') {
-                $datalog = notifyLogsModel::take($logCount)->get();
+                $datalog = notifyLogsModel::orderBy('procStartAt', $logOrder)->take($logCount)->get();
             } else if ($logModel == 'compress') {
-                $datalog = compressModel::orderBy('procStartAt', $logOrder)->take($logCount)->get();
+                $datalog = compressModel::where('result', '=', $logResult)->orderBy('procStartAt', $logOrder)->take($logCount)->get();
             } else if ($logModel == 'convert') {
-                $datalog = cnvModel::orderBy('procStartAt', $logOrder)->take($logCount)->get();
+                $datalog = cnvModel::where('result', '=', $logResult)->orderBy('procStartAt', $logOrder)->take($logCount)->get();
             } else if ($logModel == 'delete') {
-                $datalog = deleteModel::orderBy('procStartAt', $logOrder)->take($logCount)->get();
+                $datalog = deleteModel::where('result', '=', $logResult)->orderBy('procStartAt', $logOrder)->take($logCount)->get();
             } else if ($logModel == 'html') {
-                $datalog = htmlModel::orderBy('procStartAt', $logOrder)->take($logCount)->get();
+                $datalog = htmlModel::where('result', '=', $logResult)->orderBy('procStartAt', $logOrder)->take($logCount)->get();
             } else if ($logModel == 'merge') {
-                $datalog = mergeModel::orderBy('procStartAt', $logOrder)->take($logCount)->get();
+                $datalog = mergeModel::where('result', '=', $logResult)->orderBy('procStartAt', $logOrder)->take($logCount)->get();
             } else if ($logModel == 'split') {
-                $datalog = splitModel::orderBy('procStartAt', $logOrder)->take($logCount)->get();
+                $datalog = splitModel::where('result', '=', $logResult)->orderBy('procStartAt', $logOrder)->take($logCount)->get();
             } else if ($logModel == 'watermark') {
-                $datalog = watermarkModel::orderBy('procStartAt', $logOrder)->take($logCount)->get();
+                $datalog = watermarkModel::where('result', '=', $logResult)->orderBy('procStartAt', $logOrder)->take($logCount)->get();
             }
             $dataArrayLog = $datalog->toArray();
             return $this->returnDataMesage(

--- a/app/Http/Controllers/Api/File/uploadController.php
+++ b/app/Http/Controllers/Api/File/uploadController.php
@@ -107,4 +107,94 @@ class uploadController extends Controller
             }
         }
     }
+
+    public function getTotalPagesPDF(Request $request) {
+		$validator = Validator::make($request->all(),[
+			'fileName' => 'required'
+		]);
+
+		if ($validator->fails()) {
+            return $this->returnFileMesage(
+                401,
+                'Validation failed',
+                null,
+                $validator->messages()->first()
+            );
+		} else {
+			if($request->has('fileName')) {
+                $pdfName = $request->post('fileName');
+                $currentFileName = basename($pdfName);
+                $currentFileNameExtension = pathinfo($currentFileName, PATHINFO_EXTENSION);
+                $pdfUpload_Location = env('PDF_UPLOAD');
+                $newFilePath = Storage::disk('local')->path('public/'.$pdfUpload_Location.'/'.$currentFileName);
+                $fileSize = filesize($newFilePath);
+                $newFileSize = AppHelper::instance()->convert($fileSize, "MB");
+                if (file_exists($newFilePath)) {
+                    if ($currentFileNameExtension == 'pdf') {
+                        try {
+                            $pdfTotalPages = AppHelper::instance()->count($newFilePath);
+                            return $this->returnCoreMessage(
+                                200,
+                                $pdfTotalPages,
+                                $currentFileName,
+                                $newFilePath,
+                                'getTotalPDFPages',
+                                null,
+                                null,
+                                null,
+                                null,
+                                null
+                            );
+                        } catch (\Exception $e) {
+                            return $this->returnCoreMessage(
+                                200,
+                                'Failed to count total PDF pages from '.$currentFileName,
+                                $currentFileName,
+                                $newFilePath,
+                                'getTotalPDFPages',
+                                null,
+                                null,
+                                null,
+                                null,
+                                $e->getMessage()
+                            );
+                        }
+                    } else {
+                        return $this->returnCoreMessage(
+                            200,
+                            'File '.$currentFileName.' is not PDF file !',
+                            $currentFileName,
+                            $newFilePath,
+                            'getTotalPDFPages',
+                            null,
+                            null,
+                            null,
+                            null,
+                            'FILE_FORMAT_VALIDATION_EXCEPTION'
+                        );
+                    }
+                } else {
+                    return $this->returnCoreMessage(
+                        200,
+                        'File '.$currentFileName.' not found !',
+                        $currentFileName,
+                        $newFilePath,
+                        'getTotalPDFPages',
+                        null,
+                        null,
+                        null,
+                        null,
+                        'FILE_NOT_FOUND_EXCEPTION'
+                    );
+                }
+            } else {
+                return $this->returnFileMesage(
+                    200,
+                    'Failed to upload file !',
+                    null,
+                    'Requested file could not be found in the server'
+                );
+            }
+        }
+    }
 }

--- a/app/Http/Controllers/Api/versionController.php
+++ b/app/Http/Controllers/Api/versionController.php
@@ -87,7 +87,7 @@ class versionController extends Controller {
             $appServicesReferrerFE = $request->post('appServicesReferrer');
             $appMajorVersionBE = 3;
             $appMinorVersionBE = 2;
-            $appPatchVersionBE = 6;
+            $appPatchVersionBE = 7;
             $appGitVersionBE = appHelper::instance()->getGitCommitHash();
             $appServicesReferrerBE = "BE";
             $validateBE = false;

--- a/routes/api.php
+++ b/routes/api.php
@@ -51,6 +51,7 @@ Route::middleware(['auth:api'],['throttle:api'])->prefix('v1/file')->group(funct
     Route::post('upload', [uploadController::class, 'upload']);
     Route::post('remove', [uploadController::class, 'remove']);
     Route::post('thumbnail', [thumbnailController::class, 'getThumbnail']);
+    Route::post('getTotalPagesPDF', [uploadController::class, 'getTotalPagesPDF']);
 });
 
 Route::middleware(['auth:api'],['throttle:api'])->prefix('v1/logs')->group(function() {


### PR DESCRIPTION
Recent changelog: 
- [Console: Properly tell instances that run scheduler](https://github.com/Nicklas373/Hana-PDF/commit/c35995443cd7a3dda5925c95d339d20188318a6f)
- [Controllers: htmltopdf: Drop Auto](https://github.com/Nicklas373/Hana-PDF/commit/29495bd8ca96f18019f9ec5e44f14c3dea19389c)
- [Controllers: Split: Add guard logic for totalpdfpages](https://github.com/Nicklas373/Hana-PDF/commit/576ef916178bf9c6b56914818282912c9e31b2c0)
- [Notify: Include logresult to find data](https://github.com/Nicklas373/Hana-PDF/commit/86c5a4f99694023a85ae9eb8f268a5e5d3df2a5e)
- [Upload: Add new function to count total pdf pages](https://github.com/Nicklas373/Hana-PDF/commit/bd662310a92a3b2a17720cc917ca5b4173b9e71e)
- [Version: Bump to v3.2.7](https://github.com/Nicklas373/Hana-PDF/commit/c0ef7f7c041c442edad464d8520a2b11626aba99)