### PR TITLE
[HOTFIX][BE] Fix wrong file downloaded on split PDF

### DIFF
--- a/app/Http/Controllers/Api/Core/compressController.php
+++ b/app/Http/Controllers/Api/Core/compressController.php
@@ -123,6 +123,11 @@ class compressController extends Controller
                     $newFilePath = Storage::disk('local')->path('public/'.$pdfUpload_Location.'/'.$trimPhase1);
                     $fileSize = filesize($newFilePath);
                     $newFileSize = AppHelper::instance()->convert($fileSize, "MB");
+                    if ($loopCount <= 1) {
+                        if (Storage::disk('local')->exists('public/'.$pdfDownload_Location.'/'.$trimPhase1)) {
+                            Storage::disk('local')->delete('public/'.$pdfDownload_Location.'/'.$trimPhase1);
+                        }
+                    }
                     try {
                         $ilovepdf = new Ilovepdf(env('ILOVEPDF_PUBLIC_KEY'),env('ILOVEPDF_SECRET_KEY'));
                         $ilovepdfTask = $ilovepdf->newTask('compress');

--- a/app/Http/Controllers/Api/Core/convertController.php
+++ b/app/Http/Controllers/Api/Core/convertController.php
@@ -146,6 +146,11 @@ class convertController extends Controller
                     $pdfTotalPages = AppHelper::instance()->count($newFilePath);
                     $pdfNameWithExtension = pathinfo($currentFileName, PATHINFO_EXTENSION);
                     if ($convertType == 'xlsx') {
+                        if ($loopCount <= 1) {
+                            if (Storage::disk('local')->exists('public/'.$pdfDownload_Location.'/'.$newFileNameWithoutExtension.'.xlsx')) {
+                                Storage::disk('local')->delete('public/'.$pdfDownload_Location.'/'.$newFileNameWithoutExtension.'.xlsx');
+                            }
+                        }
                         $asposeAPI = new Process([
                             'python3',
                             public_path().'/ext-python/asposeAPI.py',
@@ -535,6 +540,11 @@ class convertController extends Controller
                             }
                         }
                     } else if ($convertType == 'pptx') {
+                        if ($loopCount <= 1) {
+                            if (Storage::disk('local')->exists('public/'.$pdfDownload_Location.'/'.$newFileNameWithoutExtension.'.pptx')) {
+                                Storage::disk('local')->delete('public/'.$pdfDownload_Location.'/'.$newFileNameWithoutExtension.'.pptx');
+                            }
+                        }
                         $asposeAPI = new Process([
                             'python3',
                             public_path().'/ext-python/asposeAPI.py',
@@ -924,6 +934,11 @@ class convertController extends Controller
                             }
                         }
                     } else if ($convertType == 'docx') {
+                        if ($loopCount <= 1) {
+                            if (Storage::disk('local')->exists('public/'.$pdfDownload_Location.'/'.$newFileNameWithoutExtension.'.docx')) {
+                                Storage::disk('local')->delete('public/'.$pdfDownload_Location.'/'.$newFileNameWithoutExtension.'.docx');
+                            }
+                        }
                         try {
                             $wordsApi = new WordsApi(env('ASPOSE_CLOUD_CLIENT_ID'), env('ASPOSE_CLOUD_TOKEN'));
                             $uploadFileRequest = new UploadFileRequest($newFilePath, $currentFileName);
@@ -1192,6 +1207,13 @@ class convertController extends Controller
                             }
                         }
                     } else if ($convertType == 'jpg') {
+                        if ($loopCount <= 1) {
+                            if (Storage::disk('local')->exists('public/'.$pdfDownload_Location.'/'.$newFileNameWithoutExtension.'.jpg')) {
+                                Storage::disk('local')->delete('public/'.$pdfDownload_Location.'/'.$newFileNameWithoutExtension.'.jpg');
+                            } else if (Storage::disk('local')->exists('public/'.$pdfDownload_Location.'/'.$newFileNameWithoutExtension.'-0001.jpg')) {
+                                Storage::disk('local')->delete('public/'.$pdfDownload_Location.'/'.$newFileNameWithoutExtension.'-0001.jpg');
+                            }
+                        }
                         try {
                             $ilovepdfTask = new PdfjpgTask(env('ILOVEPDF_PUBLIC_KEY'),env('ILOVEPDF_SECRET_KEY'));
                             $ilovepdfTask->setFileEncryption($pdfEncKey);
@@ -1890,6 +1912,11 @@ class convertController extends Controller
                             }
                         }
                     } else if ($convertType == 'pdf') {
+                        if ($loopCount <= 1) {
+                            if (Storage::disk('local')->exists('public/'.$pdfDownload_Location.'/'.$newFileNameWithoutExtension.'.pdf')) {
+                                Storage::disk('local')->delete('public/'.$pdfDownload_Location.'/'.$newFileNameWithoutExtension.'.pdf');
+                            }
+                        }
                         if ($pdfNameWithExtension == "jpg" || $pdfNameWithExtension == "jpeg" || $pdfNameWithExtension == "png" || $pdfNameWithExtension == "tiff") {
                             try {
                                 $ilovepdfTask = new ImagepdfTask(env('ILOVEPDF_PUBLIC_KEY'),env('ILOVEPDF_SECRET_KEY'));

--- a/app/Http/Controllers/Api/Core/htmltopdfController.php
+++ b/app/Http/Controllers/Api/Core/htmltopdfController.php
@@ -175,6 +175,9 @@ class htmltopdfController extends Controller
                     }
                 }
             }
+            if (Storage::disk('local')->exists('public/'.$pdfProcessed_Location.'/'.$pdfDefaultFileName)) {
+                Storage::disk('local')->delete('public/'.$pdfProcessed_Location.'/'.$pdfDefaultFileName);
+            }
             try {
                 $ilovepdfTask = new HtmlpdfTask(env('ILOVEPDF_PUBLIC_KEY'),env('ILOVEPDF_SECRET_KEY'));
                 $ilovepdfTask->setEncryptKey($pdfEncKey);

--- a/app/Http/Controllers/Api/Core/splitController.php
+++ b/app/Http/Controllers/Api/Core/splitController.php
@@ -116,6 +116,11 @@ class splitController extends Controller
                     $newFilePath = Storage::disk('local')->path('public/'.$pdfUpload_Location.'/'.$trimPhase1);
                     $fileSize = filesize($newFilePath);
                     $newFileSize = AppHelper::instance()->convert($fileSize, "MB");
+                    if ($tempPDF == 'true') {
+                        if (Storage::disk('local')->exists('public/'.$pdfDownload_Location.'/'.$newFileNameWithoutExtension.'.pdf')) {
+                            Storage::disk('local')->delete('public/'.$pdfDownload_Location.'/'.$newFileNameWithoutExtension.'.pdf');
+                        }
+                    }
                     if ($request->has('action')) {
                         if ($tempPDF == 'true') {
                             $mergeDBpdf = "true";
@@ -1048,7 +1053,7 @@ class splitController extends Controller
                                         'fixedRange' => $newPageRanges,
                                         'mergePDF' => $mergeDBpdf,
                                         'action' => $action,
-                                        'result' => false,
+                                        'result' => true,
                                         'isBatch' => $batchValue,
                                         'processId' => $uuid,
                                         'batchId' => $batchId,

--- a/app/Http/Controllers/Api/Core/watermarkController.php
+++ b/app/Http/Controllers/Api/Core/watermarkController.php
@@ -33,7 +33,7 @@ class watermarkController extends Controller
             'wmFontFamily' => ['required', 'in:Arial,Arial Unicode MS,Comic Sans MS,Courier,Times New Roman,Verdana'],
             'wmLayoutStyle' => ['required', 'in:above,below'],
             'wmRotation' => ['nullable', 'numeric'],
-            'wmPage' => ['nullable', 'regex:/^[0-9a-zA-Z,]+$/'],
+            'wmPage' => ['nullable', 'regex:/^[0-9a-zA-Z,-]+$/'],
             'wmText' => ['nullable','string'],
             'wmTransparency' => ['nullable', 'numeric'],
             'wmMosaic' => ['required', 'in:true,false']
@@ -114,6 +114,9 @@ class watermarkController extends Controller
                     $fileSize = filesize($newFilePath);
                     $newFileSize = AppHelper::instance()->convert($fileSize, "MB");
                     $watermarkAction = $request->post('action');
+                    if (Storage::disk('local')->exists('public/'.$pdfDownload_Location.'/'.$newFileNameWithoutExtension.'.pdf')) {
+                        Storage::disk('local')->delete('public/'.$pdfDownload_Location.'/'.$newFileNameWithoutExtension.'.pdf');
+                    }
                     if ($watermarkAction == 'img') {
                         $watermarkImage = $request->file('imgFile');
                         $currentImageName = basename($watermarkImage);

--- a/app/Http/Controllers/Api/versionController.php
+++ b/app/Http/Controllers/Api/versionController.php
@@ -87,7 +87,7 @@ class versionController extends Controller {
             $appServicesReferrerFE = $request->post('appServicesReferrer');
             $appMajorVersionBE = 3;
             $appMinorVersionBE = 2;
-            $appPatchVersionBE = 7;
+            $appPatchVersionBE = 9;
             $appGitVersionBE = appHelper::instance()->getGitCommitHash();
             $appVersioningBE = null;
             $appVersioningFE = null;

--- a/app/Http/Controllers/Api/versionController.php
+++ b/app/Http/Controllers/Api/versionController.php
@@ -86,8 +86,8 @@ class versionController extends Controller {
             $appGitVersionFE = $request->post('appGitVersion');
             $appServicesReferrerFE = $request->post('appServicesReferrer');
             $appMajorVersionBE = 3;
-            $appMinorVersionBE = 2;
-            $appPatchVersionBE = 9;
+            $appMinorVersionBE = 3;
+            $appPatchVersionBE = 0;
             $appGitVersionBE = appHelper::instance()->getGitCommitHash();
             $appVersioningBE = null;
             $appVersioningFE = null;

--- a/app/Models/accessLogsModel.php
+++ b/app/Models/accessLogsModel.php
@@ -14,8 +14,6 @@ class accessLogsModel extends Model
     protected $fillable = [
         'processId',
         'routePath',
-        'accessIpAddress',
-        'routeExceptionMessage',
-        'routeExceptionLog'
+        'accessIpAddress'
     ];
 }

--- a/app/Models/appLogsModel.php
+++ b/app/Models/appLogsModel.php
@@ -14,6 +14,6 @@ class appLogsModel extends Model
     protected $fillable = [
         'processId',
         'errReason',
-        'errApiReason'
+        'errStatus'
     ];
 }

--- a/app/Models/notifyLogsModel.php
+++ b/app/Models/notifyLogsModel.php
@@ -16,8 +16,6 @@ class notifyLogsModel extends Model
         'notifyName',
         'notifyResult',
         'notifyMessage',
-        'notifyResponse',
-        'notifyErrStatus',
-        'notifiyErrMessage'
+        'notifyResponse'
     ];
 }

--- a/composer.lock
+++ b/composer.lock
@@ -229,16 +229,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.4.0",
+            "version": "3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32"
+                "reference": "c51258e759afdb17f1fd1fe83bc12baaef6309d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/35e8d0af4486141bc745f23a29cc2091eb624a32",
-                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32",
+                "url": "https://api.github.com/repos/composer/semver/zipball/c51258e759afdb17f1fd1fe83bc12baaef6309d6",
+                "reference": "c51258e759afdb17f1fd1fe83bc12baaef6309d6",
                 "shasum": ""
             },
             "require": {
@@ -290,7 +290,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.0"
+                "source": "https://github.com/composer/semver/tree/3.4.2"
             },
             "funding": [
                 {
@@ -306,20 +306,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-31T09:50:34+00:00"
+            "time": "2024-07-12T11:35:52+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
-            "version": "v3.0.2",
+            "version": "v3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
-                "reference": "f41715465d65213d644d3141a6a93081be5d3549"
+                "reference": "a23a2bf4f31d3518f3ecb38660c95715dfead60f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/f41715465d65213d644d3141a6a93081be5d3549",
-                "reference": "f41715465d65213d644d3141a6a93081be5d3549",
+                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/a23a2bf4f31d3518f3ecb38660c95715dfead60f",
+                "reference": "a23a2bf4f31d3518f3ecb38660c95715dfead60f",
                 "shasum": ""
             },
             "require": {
@@ -379,9 +379,9 @@
             ],
             "support": {
                 "issues": "https://github.com/dflydev/dflydev-dot-access-data/issues",
-                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.2"
+                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
             },
-            "time": "2022-10-27T11:44:00+00:00"
+            "time": "2024-07-08T12:26:09+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -1480,16 +1480,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v11.14.0",
+            "version": "v11.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "657e8464e13147d56bc3a399115c8c26f38d4821"
+                "reference": "ba85f1c019bed59b3c736c9c4502805efd0ba84b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/657e8464e13147d56bc3a399115c8c26f38d4821",
-                "reference": "657e8464e13147d56bc3a399115c8c26f38d4821",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/ba85f1c019bed59b3c736c9c4502805efd0ba84b",
+                "reference": "ba85f1c019bed59b3c736c9c4502805efd0ba84b",
                 "shasum": ""
             },
             "require": {
@@ -1595,7 +1595,7 @@
                 "nyholm/psr7": "^1.2",
                 "orchestra/testbench-core": "^9.1.5",
                 "pda/pheanstalk": "^5.0",
-                "phpstan/phpstan": "^1.4.7",
+                "phpstan/phpstan": "^1.11.5",
                 "phpunit/phpunit": "^10.5|^11.0",
                 "predis/predis": "^2.0.2",
                 "resend/resend-php": "^0.10.0",
@@ -1682,7 +1682,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2024-07-02T17:23:58+00:00"
+            "time": "2024-07-09T15:38:12+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -8124,16 +8124,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.16.1",
+            "version": "v1.16.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "9266a47f1b9231b83e0cfd849009547329d871b1"
+                "reference": "51f1ba679a6afe0315621ad143d788bd7ded0eca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/9266a47f1b9231b83e0cfd849009547329d871b1",
-                "reference": "9266a47f1b9231b83e0cfd849009547329d871b1",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/51f1ba679a6afe0315621ad143d788bd7ded0eca",
+                "reference": "51f1ba679a6afe0315621ad143d788bd7ded0eca",
                 "shasum": ""
             },
             "require": {
@@ -8186,20 +8186,20 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2024-06-18T16:50:05+00:00"
+            "time": "2024-07-09T15:58:08+00:00"
         },
         {
             "name": "laravel/sail",
-            "version": "v1.30.1",
+            "version": "v1.30.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "8ba049b6c06e0330b6aa1fb7af2746fb4da445e4"
+                "reference": "f5a9699a1001e15de1aa5e7cb5c9f50a3f63f887"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/8ba049b6c06e0330b6aa1fb7af2746fb4da445e4",
-                "reference": "8ba049b6c06e0330b6aa1fb7af2746fb4da445e4",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/f5a9699a1001e15de1aa5e7cb5c9f50a3f63f887",
+                "reference": "f5a9699a1001e15de1aa5e7cb5c9f50a3f63f887",
                 "shasum": ""
             },
             "require": {
@@ -8249,7 +8249,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2024-07-01T20:55:03+00:00"
+            "time": "2024-07-05T16:01:51+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -8872,16 +8872,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.25",
+            "version": "10.5.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "831bf82312be6037e811833ddbea0b8de60ea314"
+                "reference": "2425f713b2a5350568ccb1a2d3984841a23e83c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/831bf82312be6037e811833ddbea0b8de60ea314",
-                "reference": "831bf82312be6037e811833ddbea0b8de60ea314",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2425f713b2a5350568ccb1a2d3984841a23e83c5",
+                "reference": "2425f713b2a5350568ccb1a2d3984841a23e83c5",
                 "shasum": ""
             },
             "require": {
@@ -8891,26 +8891,26 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.12.0",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.1.5",
-                "phpunit/php-file-iterator": "^4.0",
-                "phpunit/php-invoker": "^4.0",
-                "phpunit/php-text-template": "^3.0",
-                "phpunit/php-timer": "^6.0",
-                "sebastian/cli-parser": "^2.0",
-                "sebastian/code-unit": "^2.0",
-                "sebastian/comparator": "^5.0",
-                "sebastian/diff": "^5.0",
-                "sebastian/environment": "^6.0",
-                "sebastian/exporter": "^5.1",
-                "sebastian/global-state": "^6.0.1",
-                "sebastian/object-enumerator": "^5.0",
-                "sebastian/recursion-context": "^5.0",
-                "sebastian/type": "^4.0",
-                "sebastian/version": "^4.0"
+                "phpunit/php-code-coverage": "^10.1.15",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.1",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.2",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.0",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
             },
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files"
@@ -8953,7 +8953,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.25"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.27"
             },
             "funding": [
                 {
@@ -8969,7 +8969,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T05:49:17+00:00"
+            "time": "2024-07-10T11:48:06+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -9952,16 +9952,16 @@
         },
         {
             "name": "spatie/error-solutions",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/error-solutions.git",
-                "reference": "264a7eef892aceb2fd65e206127ad3af4f3a2d6b"
+                "reference": "4bb6c734dc992b2db3e26df1ef021c75d2218b13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/error-solutions/zipball/264a7eef892aceb2fd65e206127ad3af4f3a2d6b",
-                "reference": "264a7eef892aceb2fd65e206127ad3af4f3a2d6b",
+                "url": "https://api.github.com/repos/spatie/error-solutions/zipball/4bb6c734dc992b2db3e26df1ef021c75d2218b13",
+                "reference": "4bb6c734dc992b2db3e26df1ef021c75d2218b13",
                 "shasum": ""
             },
             "require": {
@@ -10014,7 +10014,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/error-solutions/issues",
-                "source": "https://github.com/spatie/error-solutions/tree/1.0.4"
+                "source": "https://github.com/spatie/error-solutions/tree/1.0.5"
             },
             "funding": [
                 {
@@ -10022,7 +10022,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-06-28T13:33:04+00:00"
+            "time": "2024-07-09T12:13:32+00:00"
         },
         {
             "name": "spatie/flare-client-php",

--- a/database/migrations/2024_01_01_000001_create_compression_pdfs_table.php
+++ b/database/migrations/2024_01_01_000001_create_compression_pdfs_table.php
@@ -33,6 +33,7 @@ return new class extends Migration
             $table->text('procDuration')->nullable();
             $table->boolean('isReport')->nullable()->default(false);
             $table->timestamp('createdAt')->nullable()->useCurrent()->useCurrentOnUpdate();
+            $table->timestamp('updatedAt')->nullable()->useCurrentOnUpdate();
 
             // Configure foreign key
             $table->foreign('processId')->references('processId')->on('appLogs');

--- a/database/migrations/2024_01_01_000002_create_merge_pdfs_table.php
+++ b/database/migrations/2024_01_01_000002_create_merge_pdfs_table.php
@@ -31,6 +31,7 @@ return new class extends Migration
             $table->text('procDuration')->nullable();
             $table->boolean('isReport')->nullable()->default(false);
             $table->timestamp('createdAt')->nullable()->useCurrent()->useCurrentOnUpdate();
+            $table->timestamp('updatedAt')->nullable()->useCurrentOnUpdate();
 
             // Configure foreign key
             $table->foreign('processId')->references('processId')->on('appLogs');

--- a/database/migrations/2024_01_01_000003_create_split_pdfs_table.php
+++ b/database/migrations/2024_01_01_000003_create_split_pdfs_table.php
@@ -24,9 +24,9 @@ return new class extends Migration
             $table->string('fileSize', 25)->nullable();
             $table->string('fromPage', 5)->nullable();
             $table->string('toPage', 5)->nullable();
-            $table->text('customPage')->nullable();
-            $table->text('fixedPage')->nullable();
-            $table->text('fixedPageRange')->nullable();
+            $table->text('customSplitPage')->nullable();
+            $table->text('customDeletePage')->nullable();
+            $table->text('fixedRange')->nullable();
             $table->string('mergePDF', 25)->nullable();
             $table->string('action', 10)->nullable();
             $table->boolean('result');
@@ -38,6 +38,7 @@ return new class extends Migration
             $table->text('procDuration')->nullable();
             $table->boolean('isReport')->nullable()->default(false);
             $table->timestamp('createdAt')->nullable()->useCurrent()->useCurrentOnUpdate();
+            $table->timestamp('updatedAt')->nullable()->useCurrentOnUpdate();
 
             // Configure foreign key
             $table->foreign('processId')->references('processId')->on('appLogs');

--- a/database/migrations/2024_01_01_000005_create_pdf_cnv_table.php
+++ b/database/migrations/2024_01_01_000005_create_pdf_cnv_table.php
@@ -33,6 +33,7 @@ return new class extends Migration
             $table->text('procDuration')->nullable();
             $table->boolean('isReport')->nullable()->default(false);
             $table->timestamp('createdAt')->nullable()->useCurrent()->useCurrentOnUpdate();
+            $table->timestamp('updatedAt')->nullable()->useCurrentOnUpdate();
 
             // Configure foreign key
             $table->foreign('processId')->references('processId')->on('appLogs');

--- a/database/migrations/2024_01_01_000005_create_watermark_pdfs_table.php
+++ b/database/migrations/2024_01_01_000005_create_watermark_pdfs_table.php
@@ -42,6 +42,7 @@ return new class extends Migration
             $table->text('procDuration')->nullable();
             $table->boolean('isReport')->nullable()->default(false);
             $table->timestamp('createdAt')->nullable()->useCurrent()->useCurrentOnUpdate();
+            $table->timestamp('updatedAt')->nullable()->useCurrentOnUpdate();
 
             // Configure foreign key
             $table->foreign('processId')->references('processId')->on('appLogs');

--- a/database/migrations/2024_01_01_000006_create_html_pdfs_table.php
+++ b/database/migrations/2024_01_01_000006_create_html_pdfs_table.php
@@ -32,6 +32,7 @@ return new class extends Migration
             $table->text('procDuration')->nullable();
             $table->boolean('isReport')->nullable()->default(false);
             $table->timestamp('createdAt')->nullable()->useCurrent()->useCurrentOnUpdate();
+            $table->timestamp('updatedAt')->nullable()->useCurrentOnUpdate();
 
             // Configure foreign key
             $table->foreign('processId')->references('processId')->on('appLogs');

--- a/database/migrations/2024_01_01_000007_create_datalogs_table.php
+++ b/database/migrations/2024_01_01_000007_create_datalogs_table.php
@@ -28,6 +28,7 @@ return new class extends Migration
             $table->timestamp('procEndAt')->nullable();
             $table->text('procDuration')->nullable();
             $table->uuid('processId');
+            $table->timestamp('createdAt')->nullable()->useCurrent()->useCurrentOnUpdate();
 
             // Configure foreign key
             $table->foreign('processId')->references('processId')->on('appLogs');

--- a/database/migrations/2024_01_01_000008_create_accesslogs_table.php
+++ b/database/migrations/2024_01_01_000008_create_accesslogs_table.php
@@ -23,6 +23,7 @@ return new class extends Migration
             $table->uuid('processId');
             $table->text('routePath')->nullable();
             $table->text('accessIpAddress')->nullable();
+            $table->timestamp('createdAt')->nullable()->useCurrent()->useCurrentOnUpdate();
 
             // Configure foreign key
             $table->foreign('processId')->references('processId')->on('appLogs');

--- a/database/migrations/2024_01_01_000009_create_notifylogs_table.php
+++ b/database/migrations/2024_01_01_000009_create_notifylogs_table.php
@@ -25,6 +25,7 @@ return new class extends Migration
             $table->boolean('notifyResult');
             $table->text('notifyMessage')->nullable();
             $table->json('notifyResponse')->nullable();
+            $table->timestamp('createdAt')->nullable()->useCurrent()->useCurrentOnUpdate();
 
             // Configure foreign key
             $table->foreign('processId')->references('processId')->on('appLogs');


### PR DESCRIPTION
## What's Fixed:
- Add logic to delete previous downloaded file, if previous downloaded filename are same with
new generated processed filename. This to prevent BE accidentally return wrong response into FE, when
notification service catch actual response.
> Ex: BE response 200 with download link, although notification service threw error notification
> 		"Cannot download from iLovePDF API !". Actual condition is BE process is fail, but since logic
> 		for decision process is success or not have another depend to check if processed filename is exist or not,
> 		and in this scenario. User processed the same filename, then that logic will think previous file is the new
> 		file due the same filename.
- Add more filter validation on split and watermark to provide "-" characters (Now user can input page: 2-5, not only 2,3,4,5)
- Add new params 'usedMethod' that will declare as identifier process, is that split or delete.
This will fixed issue sometimes logic can not catch correctly what actual request from FE, since FE
are not declare what are the request properly
- Bump BE services to 3.3.0