### PR TITLE
database: Fix wrong named column for updated_at

### DIFF
--- a/database/migrations/2024_01_01_000001_create_compression_pdfs_table.php
+++ b/database/migrations/2024_01_01_000001_create_compression_pdfs_table.php
@@ -33,7 +33,7 @@ return new class extends Migration
             $table->text('procDuration')->nullable();
             $table->boolean('isReport')->nullable()->default(false);
             $table->timestamp('createdAt')->nullable()->useCurrent()->useCurrentOnUpdate();
-            $table->timestamp('updatedAt')->nullable()->useCurrentOnUpdate();
+            $table->timestamp('updated_at')->nullable()->useCurrentOnUpdate();
 
             // Configure foreign key
             $table->foreign('processId')->references('processId')->on('appLogs');

--- a/database/migrations/2024_01_01_000002_create_merge_pdfs_table.php
+++ b/database/migrations/2024_01_01_000002_create_merge_pdfs_table.php
@@ -31,7 +31,7 @@ return new class extends Migration
             $table->text('procDuration')->nullable();
             $table->boolean('isReport')->nullable()->default(false);
             $table->timestamp('createdAt')->nullable()->useCurrent()->useCurrentOnUpdate();
-            $table->timestamp('updatedAt')->nullable()->useCurrentOnUpdate();
+            $table->timestamp('updated_at')->nullable()->useCurrentOnUpdate();
 
             // Configure foreign key
             $table->foreign('processId')->references('processId')->on('appLogs');

--- a/database/migrations/2024_01_01_000003_create_split_pdfs_table.php
+++ b/database/migrations/2024_01_01_000003_create_split_pdfs_table.php
@@ -38,7 +38,7 @@ return new class extends Migration
             $table->text('procDuration')->nullable();
             $table->boolean('isReport')->nullable()->default(false);
             $table->timestamp('createdAt')->nullable()->useCurrent()->useCurrentOnUpdate();
-            $table->timestamp('updatedAt')->nullable()->useCurrentOnUpdate();
+            $table->timestamp('updated_at')->nullable()->useCurrentOnUpdate();
 
             // Configure foreign key
             $table->foreign('processId')->references('processId')->on('appLogs');

--- a/database/migrations/2024_01_01_000005_create_pdf_cnv_table.php
+++ b/database/migrations/2024_01_01_000005_create_pdf_cnv_table.php
@@ -33,7 +33,7 @@ return new class extends Migration
             $table->text('procDuration')->nullable();
             $table->boolean('isReport')->nullable()->default(false);
             $table->timestamp('createdAt')->nullable()->useCurrent()->useCurrentOnUpdate();
-            $table->timestamp('updatedAt')->nullable()->useCurrentOnUpdate();
+            $table->timestamp('updated_at')->nullable()->useCurrentOnUpdate();
 
             // Configure foreign key
             $table->foreign('processId')->references('processId')->on('appLogs');

--- a/database/migrations/2024_01_01_000005_create_watermark_pdfs_table.php
+++ b/database/migrations/2024_01_01_000005_create_watermark_pdfs_table.php
@@ -42,7 +42,7 @@ return new class extends Migration
             $table->text('procDuration')->nullable();
             $table->boolean('isReport')->nullable()->default(false);
             $table->timestamp('createdAt')->nullable()->useCurrent()->useCurrentOnUpdate();
-            $table->timestamp('updatedAt')->nullable()->useCurrentOnUpdate();
+            $table->timestamp('updated_at')->nullable()->useCurrentOnUpdate();
 
             // Configure foreign key
             $table->foreign('processId')->references('processId')->on('appLogs');

--- a/database/migrations/2024_01_01_000006_create_html_pdfs_table.php
+++ b/database/migrations/2024_01_01_000006_create_html_pdfs_table.php
@@ -32,7 +32,7 @@ return new class extends Migration
             $table->text('procDuration')->nullable();
             $table->boolean('isReport')->nullable()->default(false);
             $table->timestamp('createdAt')->nullable()->useCurrent()->useCurrentOnUpdate();
-            $table->timestamp('updatedAt')->nullable()->useCurrentOnUpdate();
+            $table->timestamp('updated_at')->nullable()->useCurrentOnUpdate();
 
             // Configure foreign key
             $table->foreign('processId')->references('processId')->on('appLogs');


### PR DESCRIPTION
Rename "updatedAt" -> "updated_at" to fix dailyReport issue.

Sorry, forgot column name :(

```
SQLSTATE[42703]: Undefined column: 7 ERROR:  column "updated_at" of relation "pdfCompress" does not exist
LINE 1: update "pdfCompress" set "isReport" = $1, "updated_at" = $2 ...
                                                  ^ (Connection: pgsql, SQL: update "pdfCompress" set "isReport" = 1, "updated_at" = 2024-07-20 19:00:03 where "procStartAt" >= 2024-07-19 19:00:00 and "result" = 1 and "isReport" = 0)
```