### PR TITLE
v3.3.1 20240818 [Backend Module]

### DIFF
--- a/app/Http/Controllers/Api/Data/notifyLogController.php
+++ b/app/Http/Controllers/Api/Data/notifyLogController.php
@@ -203,11 +203,11 @@ class notifyLogController extends Controller
         $logOrder = $request->input('logOrder');
         try {
             if ($logModel == 'access') {
-                $datalog = accessLogsModel::take($logCount)->get();
+                $datalog = accessLogsModel::orderBy('createdAt', $logOrder)->take($logCount)->get();
             } else if ($logModel == 'jobs') {
                 $datalog = jobLogsModel::orderBy('procStartAt', $logOrder)->take($logCount)->get();
             } else if ($logModel == 'notify') {
-                $datalog = notifyLogsModel::take($logCount)->get();
+                $datalog = notifyLogsModel::orderBy('createdAt', $logOrder)->take($logCount)->get();
             } else if ($logModel == 'compress') {
                 $datalog = compressModel::where('result', '=', $logResult)->orderBy('procStartAt', $logOrder)->take($logCount)->get();
             } else if ($logModel == 'convert') {

--- a/app/Http/Controllers/Api/versionController.php
+++ b/app/Http/Controllers/Api/versionController.php
@@ -87,7 +87,7 @@ class versionController extends Controller {
             $appServicesReferrerFE = $request->post('appServicesReferrer');
             $appMajorVersionBE = 3;
             $appMinorVersionBE = 3;
-            $appPatchVersionBE = 0;
+            $appPatchVersionBE = 1;
             $appGitVersionBE = appHelper::instance()->getGitCommitHash();
             $appVersioningBE = null;
             $appVersioningFE = null;

--- a/composer.lock
+++ b/composer.lock
@@ -2075,16 +2075,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.5.2",
+            "version": "2.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "df09d5b6a4188f8f3c3ab2e43a109076a5eeb767"
+                "reference": "b650144166dfa7703e62a22e493b853b58d874b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/df09d5b6a4188f8f3c3ab2e43a109076a5eeb767",
-                "reference": "df09d5b6a4188f8f3c3ab2e43a109076a5eeb767",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/b650144166dfa7703e62a22e493b853b58d874b0",
+                "reference": "b650144166dfa7703e62a22e493b853b58d874b0",
                 "shasum": ""
             },
             "require": {
@@ -2097,8 +2097,8 @@
             },
             "require-dev": {
                 "cebe/markdown": "^1.0",
-                "commonmark/cmark": "0.31.0",
-                "commonmark/commonmark.js": "0.31.0",
+                "commonmark/cmark": "0.31.1",
+                "commonmark/commonmark.js": "0.31.1",
                 "composer/package-versions-deprecated": "^1.8",
                 "embed/embed": "^4.4",
                 "erusev/parsedown": "^1.0",
@@ -2177,7 +2177,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-14T10:56:57+00:00"
+            "time": "2024-08-16T11:46:16+00:00"
         },
         {
             "name": "league/config",


### PR DESCRIPTION
Recent Changelog:

[Controllers: Split: Try to handle un-count custom pages](https://github.com/Nicklas373/Hana-PDF/commit/bdd70967a01cd3db53d93fa5d2858a1104f4ccd7)

Description:
In some condition when custom page ranges was inputted, value sometimes are not
really custom. It can be integer without any string on it, in that case hana-pdf
can threw overflow integer into iLovePDF API.

Although it should be return error from iLovePDF, but it should be good if it can be
handle from backend instead. Apply more guard logic to protect if value was input on
custom page are integer, then do logic to check if page number are not more that total
pdf pages.

And also properly include some database insert on some error, it should be tracked too.
