### PR TITLE
[BE][HOTFIX]: Fix may-nullable validation params

### DIFF
--- a/app/Http/Controllers/Api/Core/splitController.php
+++ b/app/Http/Controllers/Api/Core/splitController.php
@@ -29,8 +29,8 @@ class splitController extends Controller
             'fromPage' => ['nullable', 'numeric'],
             'toPage' => ['nullable', 'numeric'],
             'mergePDF' => ['required', 'in:true,false'],
-            'customPageSplit' => ['nullable', 'regex:/^[0-9,-]+$/'],
-            'customPageDelete' => ['nullable', 'regex:/^[0-9,-]+$/'],
+            'customPageSplit' => ['required', 'regex:/^(all|[0-9,-]+)$/'],
+            'customPageDelete' => ['required', 'regex:/^(all|[0-9,-]+)$/'],
             'usedMethod' => ['required', 'in:range,custom']
 		]);
 

--- a/app/Http/Controllers/Api/Core/watermarkController.php
+++ b/app/Http/Controllers/Api/Core/watermarkController.php
@@ -27,13 +27,13 @@ class watermarkController extends Controller
             'file' => '',
             'imgFile' => '',
             'action' => ['required', 'in:img,txt'],
-            'wmFontColor' => ['required','regex:/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/'],
-            'wmFontSize' => ['required', 'numeric'],
+            'wmFontColor' => ['nullable','regex:/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/'],
+            'wmFontSize' => ['nullable', 'numeric'],
             'wmFontStyle' => ['required', 'in:Regular,Bold,Italic'],
             'wmFontFamily' => ['required', 'in:Arial,Arial Unicode MS,Comic Sans MS,Courier,Times New Roman,Verdana'],
             'wmLayoutStyle' => ['required', 'in:above,below'],
             'wmRotation' => ['required', 'numeric'],
-            'wmPage' => ['required', 'regex:/^[0-9a-zA-Z,-]+$/'],
+            'wmPage' => ['required', 'regex:/^(all|[0-9,-]+)$/'],
             'wmText' => ['nullable','string'],
             'wmTransparency' => ['required', 'numeric'],
             'wmMosaic' => ['required', 'in:true,false']
@@ -118,10 +118,11 @@ class watermarkController extends Controller
                         $randomizeImageExtension = pathinfo($watermarkImage->getClientOriginalName(), PATHINFO_EXTENSION);
                         $wmImageName = $newFileNameWithoutExtension.'.'.$randomizeImageExtension;
                         $watermarkImage->storeAs('public/upload', $wmImageName);
+                        $watermarkText = null;
                     } else if ($watermarkAction == 'txt') {
-                        $wmImageName = '';
                         $watermarkText = $request->post('wmText');
-                        if (empty($watermarkImage)) {
+                        $wmImageName = null;
+                        if (empty($watermarkText)) {
                             return $this->returnDataMesage(
                                 400,
                                 'PDF Watermark failed !',

--- a/app/Http/Controllers/Api/File/uploadController.php
+++ b/app/Http/Controllers/Api/File/uploadController.php
@@ -130,7 +130,7 @@ class uploadController extends Controller
                 if (file_exists($newFilePath)) {
                     if ($currentFileNameExtension == 'pdf') {
                         try {
-                            $pdf = new Pdf($pdfNewPath);
+                            $pdf = new Pdf($newFilePath);
                             $pdfTotalPages = $pdf->pageCount();
                             return $this->returnDataMesage(
                                 200,

--- a/app/Http/Controllers/Api/Misc/versionController.php
+++ b/app/Http/Controllers/Api/Misc/versionController.php
@@ -46,7 +46,7 @@ class versionController extends Controller {
             $appServicesReferrerFE = $request->post('appServicesReferrer');
             $appMajorVersionBE = 3;
             $appMinorVersionBE = 4;
-            $appPatchVersionBE = 1;
+            $appPatchVersionBE = 2;
             $appGitVersionBE = appHelper::instance()->getGitCommitHash();
             $appVersioningBE = null;
             $appVersioningFE = null;

--- a/composer.lock
+++ b/composer.lock
@@ -8586,16 +8586,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.3.5",
+            "version": "11.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "4dc07a589a68f8f2d5132ac0849146d122e08347"
+                "reference": "d62c45a19c665bb872c2a47023a0baf41a98bb2b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4dc07a589a68f8f2d5132ac0849146d122e08347",
-                "reference": "4dc07a589a68f8f2d5132ac0849146d122e08347",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d62c45a19c665bb872c2a47023a0baf41a98bb2b",
+                "reference": "d62c45a19c665bb872c2a47023a0baf41a98bb2b",
                 "shasum": ""
             },
             "require": {
@@ -8622,7 +8622,7 @@
                 "sebastian/exporter": "^6.1.3",
                 "sebastian/global-state": "^7.0.2",
                 "sebastian/object-enumerator": "^6.0.1",
-                "sebastian/type": "^5.0.1",
+                "sebastian/type": "^5.1.0",
                 "sebastian/version": "^5.0.1"
             },
             "suggest": {
@@ -8666,7 +8666,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.3.5"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.3.6"
             },
             "funding": [
                 {
@@ -8682,7 +8682,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-13T05:22:17+00:00"
+            "time": "2024-09-19T10:54:28+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
## Description
In last update, i was update some validation logic to 'required' from 'nullable' in split and watermark controllers. But some of that value was never served from the frontend with default value when empty. And it make validation logic hit and return error validation.

## Solution
Update core API to properly declare and handle may-nullable variable, instead only declare as required

## Commit
- [Core: Fix may-nullable validation params](https://github.com/Nicklas373/Hana-PDF/commit/3eedc3d98fe074bc1223894234c161b5a3bae423)
- [File: Fix undefined variable when counted total pdf pages](https://github.com/Nicklas373/Hana-PDF/commit/b165a17f2872af05a3a33a0900dad791055598e1)

## Handling for previous pull request
#232 