### PR TITLE
[HOTFIX][BE]: Use old php native function to count PDF pages 

### DIFF
--- a/app/Helpers/AppHelper.php
+++ b/app/Helpers/AppHelper.php
@@ -42,6 +42,13 @@ class AppHelper
         }
     }
 
+    function count($path)
+    {
+        $pdf = file_get_contents($path);
+        $number = preg_match_all("/\/Page\W/", $pdf, $dummy);
+        return $number;
+    }
+
     function folderSize($dir)
     {
         $size = 0;

--- a/app/Http/Controllers/Api/Core/splitController.php
+++ b/app/Http/Controllers/Api/Core/splitController.php
@@ -14,7 +14,6 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 use Ilovepdf\Ilovepdf;
-use Spatie\PdfToImage\Pdf;
 
 class splitController extends Controller
 {
@@ -226,126 +225,14 @@ class splitController extends Controller
                             if ($action == 'split') {
                                 if ($usedMethod == 'range') {
                                     if ($fromPage != '' && $toPage != '') {
-                                        try {
-                                            $pdf = new Pdf($newFilePath);
-                                            $pdfTotalPages = $pdf->pageCount();
-                                            if ($toPage > $pdfTotalPages) {
-                                                $end = Carbon::parse(AppHelper::instance()->getCurrentTimeZone());
-                                                $duration = $end->diff($startProc);
-                                                appLogModel::where('groupId', '=', $batchId)
-                                                    ->update([
-                                                        'errReason' => 'Last page has more page than total PDF page ! (total page: '.$pdfTotalPages.')',
-                                                        'errStatus' => 'PDF split failed!'
-                                                    ]);
-                                                splitModel::where('groupId', '=', $batchId)
-                                                    ->update([
-                                                        'result' => false,
-                                                        'procEndAt' => AppHelper::instance()->getCurrentTimeZone(),
-                                                        'procDuration' => $duration->s.' seconds'
-                                                    ]);
-                                                NotificationHelper::Instance()->sendErrNotify(
-                                                    $currentFileName,
-                                                    $newFileSize,
-                                                    $batchId,
-                                                    'FAIL',
-                                                    'split',
-                                                    'PDF split failed!',
-                                                    'Last page has more page than total PDF page ! (total page: '.$pdfTotalPages.')'
-                                                );
-                                                Storage::disk('local')->delete('public/'.$pdfUpload_Location.'/'.$trimPhase1);
-                                                return $this->returnDataMesage(
-                                                    400,
-                                                    'PDF Split failed !',
-                                                    null,
-                                                    $batchId,
-                                                    null,
-                                                    'Last page has more page than total PDF page ! (total page: '.$pdfTotalPages.')'
-                                                );
-                                            } else if ($fromPage > $pdfTotalPages) {
-                                                $end = Carbon::parse(AppHelper::instance()->getCurrentTimeZone());
-                                                $duration = $end->diff($startProc);
-                                                appLogModel::where('groupId', '=', $batchId)
-                                                    ->update([
-                                                        'errReason' => 'First page has more page than total PDF page ! (total page: '.$pdfTotalPages.')',
-                                                        'errStatus' => 'PDF split failed!'
-                                                    ]);
-                                                splitModel::where('groupId', '=', $batchId)
-                                                    ->update([
-                                                        'result' => false,
-                                                        'procEndAt' => AppHelper::instance()->getCurrentTimeZone(),
-                                                        'procDuration' => $duration->s.' seconds'
-                                                    ]);
-                                                NotificationHelper::Instance()->sendErrNotify(
-                                                    $currentFileName,
-                                                    $newFileSize,
-                                                    $batchId,
-                                                    'FAIL',
-                                                    'split',
-                                                    'PDF split failed!',
-                                                    'First page has more page than total PDF page ! (total page: '.$pdfTotalPages.')'
-                                                );
-                                                Storage::disk('local')->delete('public/'.$pdfUpload_Location.'/'.$trimPhase1);
-                                                return $this->returnDataMesage(
-                                                    400,
-                                                    'PDF Split failed !',
-                                                    null,
-                                                    $batchId,
-                                                    null,
-                                                    'First page has more page than total PDF page ! (total page: '.$pdfTotalPages.')'
-                                                );
-                                            } else if ($fromPage > $toPage) {
-                                                $end = Carbon::parse(AppHelper::instance()->getCurrentTimeZone());
-                                                $duration = $end->diff($startProc);
-                                                appLogModel::where('groupId', '=', $batchId)
-                                                    ->update([
-                                                        'errReason' => 'First Page has more page than last page ! (total page: '.$pdfTotalPages.')',
-                                                        'errStatus' => 'PDF split failed!'
-                                                    ]);
-                                                splitModel::where('groupId', '=', $batchId)
-                                                    ->update([
-                                                        'result' => false,
-                                                        'procEndAt' => AppHelper::instance()->getCurrentTimeZone(),
-                                                        'procDuration' => $duration->s.' seconds'
-                                                    ]);
-                                                NotificationHelper::Instance()->sendErrNotify(
-                                                    $currentFileName,
-                                                    $newFileSize,
-                                                    $batchId,
-                                                    'FAIL',
-                                                    'split',
-                                                    'PDF split failed!',
-                                                    'First Page has more page than last page ! (total page: '.$pdfTotalPages.')'
-                                                );
-                                                Storage::disk('local')->delete('public/'.$pdfUpload_Location.'/'.$trimPhase1);
-                                                return $this->returnDataMesage(
-                                                    400,
-                                                    'PDF Split failed !',
-                                                    null,
-                                                    $batchId,
-                                                    null,
-                                                    'First Page has more page than last page ! (total page: '.$pdfTotalPages.')',
-                                                );
-                                            } else {
-                                                if ($mergeDBpdf == "true") {
-                                                    $newPageRanges = $fromPage.'-'.$toPage;
-                                                } else if ($mergeDBpdf == "false") {
-                                                    $pdfStartPages = $fromPage;
-                                                    $pdfTotalPages = $toPage;
-                                                    while($pdfStartPages <= intval($pdfTotalPages))
-                                                    {
-                                                        $pdfArrayPages[] = $pdfStartPages;
-                                                        $pdfStartPages += 1;
-                                                    }
-                                                    $newPageRanges = implode(', ', $pdfArrayPages);
-                                                }
-                                            }
-                                        } catch (\Exception $e) {
+                                        $pdfTotalPages = AppHelper::instance()->count($newFilePath);
+                                        if ($toPage > $pdfTotalPages) {
                                             $end = Carbon::parse(AppHelper::instance()->getCurrentTimeZone());
                                             $duration = $end->diff($startProc);
                                             appLogModel::where('groupId', '=', $batchId)
                                                 ->update([
-                                                    'errReason' => $e->getMessage(),
-                                                    'errStatus' => 'Failed to count total PDF pages from '.$currentFileName
+                                                    'errReason' => 'Last page has more page than total PDF page ! (total page: '.$pdfTotalPages.')',
+                                                    'errStatus' => 'PDF split failed!'
                                                 ]);
                                             splitModel::where('groupId', '=', $batchId)
                                                 ->update([
@@ -359,17 +246,95 @@ class splitController extends Controller
                                                 $batchId,
                                                 'FAIL',
                                                 'split',
-                                                'Failed to count total PDF pages from '.$currentFileName, $e->getMessage()
+                                                'PDF split failed!',
+                                                'Last page has more page than total PDF page ! (total page: '.$pdfTotalPages.')'
                                             );
                                             Storage::disk('local')->delete('public/'.$pdfUpload_Location.'/'.$trimPhase1);
                                             return $this->returnDataMesage(
                                                 400,
                                                 'PDF Split failed !',
-                                                $e->getMessage(),
+                                                null,
                                                 $batchId,
                                                 null,
-                                                'Failed to count total PDF pages from '.$currentFileName
+                                                'Last page has more page than total PDF page ! (total page: '.$pdfTotalPages.')'
                                             );
+                                        } else if ($fromPage > $pdfTotalPages) {
+                                            $end = Carbon::parse(AppHelper::instance()->getCurrentTimeZone());
+                                            $duration = $end->diff($startProc);
+                                            appLogModel::where('groupId', '=', $batchId)
+                                                ->update([
+                                                    'errReason' => 'First page has more page than total PDF page ! (total page: '.$pdfTotalPages.')',
+                                                    'errStatus' => 'PDF split failed!'
+                                                ]);
+                                            splitModel::where('groupId', '=', $batchId)
+                                                ->update([
+                                                    'result' => false,
+                                                    'procEndAt' => AppHelper::instance()->getCurrentTimeZone(),
+                                                    'procDuration' => $duration->s.' seconds'
+                                                ]);
+                                            NotificationHelper::Instance()->sendErrNotify(
+                                                $currentFileName,
+                                                $newFileSize,
+                                                $batchId,
+                                                'FAIL',
+                                                'split',
+                                                'PDF split failed!',
+                                                'First page has more page than total PDF page ! (total page: '.$pdfTotalPages.')'
+                                            );
+                                            Storage::disk('local')->delete('public/'.$pdfUpload_Location.'/'.$trimPhase1);
+                                            return $this->returnDataMesage(
+                                                400,
+                                                'PDF Split failed !',
+                                                null,
+                                                $batchId,
+                                                null,
+                                                'First page has more page than total PDF page ! (total page: '.$pdfTotalPages.')'
+                                            );
+                                        } else if ($fromPage > $toPage) {
+                                            $end = Carbon::parse(AppHelper::instance()->getCurrentTimeZone());
+                                            $duration = $end->diff($startProc);
+                                            appLogModel::where('groupId', '=', $batchId)
+                                                ->update([
+                                                    'errReason' => 'First Page has more page than last page ! (total page: '.$pdfTotalPages.')',
+                                                    'errStatus' => 'PDF split failed!'
+                                                ]);
+                                            splitModel::where('groupId', '=', $batchId)
+                                                ->update([
+                                                    'result' => false,
+                                                    'procEndAt' => AppHelper::instance()->getCurrentTimeZone(),
+                                                    'procDuration' => $duration->s.' seconds'
+                                                ]);
+                                            NotificationHelper::Instance()->sendErrNotify(
+                                                $currentFileName,
+                                                $newFileSize,
+                                                $batchId,
+                                                'FAIL',
+                                                'split',
+                                                'PDF split failed!',
+                                                'First Page has more page than last page ! (total page: '.$pdfTotalPages.')'
+                                            );
+                                            Storage::disk('local')->delete('public/'.$pdfUpload_Location.'/'.$trimPhase1);
+                                            return $this->returnDataMesage(
+                                                400,
+                                                'PDF Split failed !',
+                                                null,
+                                                $batchId,
+                                                null,
+                                                'First Page has more page than last page ! (total page: '.$pdfTotalPages.')',
+                                            );
+                                        } else {
+                                            if ($mergeDBpdf == "true") {
+                                                $newPageRanges = $fromPage.'-'.$toPage;
+                                            } else if ($mergeDBpdf == "false") {
+                                                $pdfStartPages = $fromPage;
+                                                $pdfTotalPages = $toPage;
+                                                while($pdfStartPages <= intval($pdfTotalPages))
+                                                {
+                                                    $pdfArrayPages[] = $pdfStartPages;
+                                                    $pdfStartPages += 1;
+                                                }
+                                                $newPageRanges = implode(', ', $pdfArrayPages);
+                                            }
                                         }
                                     } else {
                                         $end = Carbon::parse(AppHelper::instance()->getCurrentTimeZone());
@@ -405,95 +370,16 @@ class splitController extends Controller
                                     }
                                 } else if ($usedMethod == 'custom') {
                                     if (is_numeric($customInputSplitPage)) {
-                                        try {
-                                            $pdf = new Pdf($newFilePath);
-                                            $pdfTotalPages = $pdf->pageCount();
-                                            if ($customInputSplitPage > $pdfTotalPages) {
-                                                appLogModel::where('groupId', '=', $batchId)
-                                                    ->update([
-                                                        'errReason' => 'Input Page has more page than last page ! (total page: '.$pdfTotalPages.')',
-                                                        'errStatus' => 'PDF Split failed !'
-                                                    ]);
-                                                splitModel::where('groupId', '=', $batchId)
-                                                    ->update([
-                                                        'customSplitPage' => $customInputSplitPage,
-                                                        'result' => false,
-                                                        'procEndAt' => AppHelper::instance()->getCurrentTimeZone(),
-                                                        'procDuration' => $duration->s.' seconds'
-                                                    ]);
-                                                NotificationHelper::Instance()->sendErrNotify(
-                                                    $currentFileName,
-                                                    $newFileSize,
-                                                    $batchId,
-                                                    'FAIL',
-                                                    'split',
-                                                    'PDF split failed!',
-                                                    'Input Page has more page than last page ! (total page: '.$pdfTotalPages.')'
-                                                );
-                                                Storage::disk('local')->delete('public/'.$pdfUpload_Location.'/'.$trimPhase1);
-                                                return $this->returnDataMesage(
-                                                    400,
-                                                    'PDF Split failed !',
-                                                    null,
-                                                    $batchId,
-                                                    null,
-                                                    'Input Page has more page than last page ! (total page: '.$pdfTotalPages.')'
-                                                );
-                                            } else {
-                                                $newPageRanges = $customInputSplitPage;
-                                            }
-                                        } catch (\Exception $e) {
-                                            $end = Carbon::parse(AppHelper::instance()->getCurrentTimeZone());
-                                            $duration = $end->diff($startProc);
-                                            appLogModel::where('groupId', '=', $batchId)
-                                                ->update([
-                                                    'errReason' => $e->getMessage(),
-                                                    'errStatus' => 'Failed to count total PDF pages from '.$currentFileName
-                                                ]);
-                                            splitModel::where('groupId', '=', $batchId)
-                                                ->update([
-                                                    'result' => false,
-                                                    'procEndAt' => AppHelper::instance()->getCurrentTimeZone(),
-                                                    'procDuration' => $duration->s.' seconds'
-                                                ]);
-                                            NotificationHelper::Instance()->sendErrNotify(
-                                                $currentFileName,
-                                                $newFileSize,
-                                                $batchId,
-                                                'FAIL',
-                                                'split',
-                                                'Failed to count total PDF pages from '.$currentFileName, $e->getMessage()
-                                            );
-                                            Storage::disk('local')->delete('public/'.$pdfUpload_Location.'/'.$trimPhase1);
-                                            return $this->returnDataMesage(
-                                                400,
-                                                'PDF Split failed !',
-                                                $e->getMessage(),
-                                                $batchId,
-                                                null,
-                                                'Failed to count total PDF pages from '.$currentFileName
-                                            );
-                                        }
-                                    } else if (is_string($customInputSplitPage)) {
-                                        $newPageRanges = strtolower($customInputSplitPage);
-                                    } else {
-                                        $newPageRanges = $customInputSplitPage;
-                                    }
-                                }
-                            } else {
-                                if (is_numeric($customInputDeletePage)) {
-                                    try {
-                                        $pdf = new Pdf($newFilePath);
-                                        $pdfTotalPages = $pdf->pageCount();
-                                        if ($customInputDeletePage > $pdfTotalPages) {
+                                        $pdfTotalPages = AppHelper::instance()->count($newFilePath);
+                                        if ($customInputSplitPage > $pdfTotalPages) {
                                             appLogModel::where('groupId', '=', $batchId)
                                                 ->update([
                                                     'errReason' => 'Input Page has more page than last page ! (total page: '.$pdfTotalPages.')',
-                                                    'errStatus' => 'PDF split failed!'
+                                                    'errStatus' => 'PDF Split failed !'
                                                 ]);
                                             splitModel::where('groupId', '=', $batchId)
                                                 ->update([
-                                                    'customDeletePage' => $customInputDeletePage,
+                                                    'customSplitPage' => $customInputSplitPage,
                                                     'result' => false,
                                                     'procEndAt' => AppHelper::instance()->getCurrentTimeZone(),
                                                     'procDuration' => $duration->s.' seconds'
@@ -517,18 +403,26 @@ class splitController extends Controller
                                                 'Input Page has more page than last page ! (total page: '.$pdfTotalPages.')'
                                             );
                                         } else {
-                                            $newPageRanges = $customInputDeletePage;
+                                            $newPageRanges = $customInputSplitPage;
                                         }
-                                    } catch (\Exception $e) {
-                                        $end = Carbon::parse(AppHelper::instance()->getCurrentTimeZone());
-                                        $duration = $end->diff($startProc);
+                                    } else if (is_string($customInputSplitPage)) {
+                                        $newPageRanges = strtolower($customInputSplitPage);
+                                    } else {
+                                        $newPageRanges = $customInputSplitPage;
+                                    }
+                                }
+                            } else {
+                                if (is_numeric($customInputDeletePage)) {
+                                    $pdfTotalPages = AppHelper::instance()->count($newFilePath);
+                                    if ($customInputDeletePage > $pdfTotalPages) {
                                         appLogModel::where('groupId', '=', $batchId)
                                             ->update([
-                                                'errReason' => $e->getMessage(),
-                                                'errStatus' => 'Failed to count total PDF pages from '.$currentFileName
+                                                'errReason' => 'Input Page has more page than last page ! (total page: '.$pdfTotalPages.')',
+                                                'errStatus' => 'PDF split failed!'
                                             ]);
                                         splitModel::where('groupId', '=', $batchId)
                                             ->update([
+                                                'customDeletePage' => $customInputDeletePage,
                                                 'result' => false,
                                                 'procEndAt' => AppHelper::instance()->getCurrentTimeZone(),
                                                 'procDuration' => $duration->s.' seconds'
@@ -539,17 +433,20 @@ class splitController extends Controller
                                             $batchId,
                                             'FAIL',
                                             'split',
-                                            'Failed to count total PDF pages from '.$currentFileName, $e->getMessage()
+                                            'PDF split failed!',
+                                            'Input Page has more page than last page ! (total page: '.$pdfTotalPages.')'
                                         );
                                         Storage::disk('local')->delete('public/'.$pdfUpload_Location.'/'.$trimPhase1);
                                         return $this->returnDataMesage(
                                             400,
                                             'PDF Split failed !',
-                                            $e->getMessage(),
+                                            null,
                                             $batchId,
                                             null,
-                                            'Failed to count total PDF pages from '.$currentFileName
+                                            'Input Page has more page than last page ! (total page: '.$pdfTotalPages.')'
                                         );
+                                    } else {
+                                        $newPageRanges = $customInputDeletePage;
                                     }
                                 } else if (is_string($customInputDeletePage)) {
                                     $newPageRanges = strtolower($customInputDeletePage);

--- a/app/Http/Controllers/Api/File/fileController.php
+++ b/app/Http/Controllers/Api/File/fileController.php
@@ -7,7 +7,6 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
-use Spatie\PdfToImage\Pdf;
 
 class fileController extends Controller
 {
@@ -198,28 +197,16 @@ class fileController extends Controller
                         $minioUpload = Storage::disk('minio')->get($pdfUpload_Location.'/'.$currentFileName);
                         file_put_contents(Storage::disk('local')->path('public/'.$pdfUpload_Location.'/'.$currentFileName), $minioUpload);
                         $newFilePath = Storage::disk('local')->path('public/'.$pdfUpload_Location.'/'.$currentFileName);
-                        try {
-                            $pdf = new Pdf($newFilePath);
-                            $pdfTotalPages = $pdf->pageCount();
-                            Storage::disk('local')->delete('public/'.$pdfUpload_Location.'/'.$currentFileName);
-                            return $this->returnDataMesage(
-                                200,
-                                'PDF Page successfully counted',
-                                $pdfTotalPages,
-                                null,
-                                null,
-                                null
-                            );
-                        } catch (\Exception $e) {
-                            return $this->returnDataMesage(
-                                400,
-                                'Failed to count total PDF pages from '.$currentFileName,
-                                null,
-                                null,
-                                null,
-                                $e->getMessage()
-                            );
-                        }
+                        $pdfTotalPages = AppHelper::instance()->count($newFilePath);
+                        Storage::disk('local')->delete('public/'.$pdfUpload_Location.'/'.$currentFileName);
+                        return $this->returnDataMesage(
+                            200,
+                            'PDF Page successfully counted',
+                            $pdfTotalPages,
+                            null,
+                            null,
+                            null
+                        );
                     } else {
                         return $this->returnDataMesage(
                             400,

--- a/app/Http/Controllers/Api/Misc/versionController.php
+++ b/app/Http/Controllers/Api/Misc/versionController.php
@@ -42,7 +42,7 @@ class versionController extends Controller {
             $appServicesReferrerFE = $request->post('appServicesReferrer');
             $appMajorVersionBE = 3;
             $appMinorVersionBE = 6;
-            $appPatchVersionBE = 3;
+            $appPatchVersionBE = 4;
             $appVersioningBE = null;
             $appVersioningFE = null;
             $appServicesReferrerBE = "BE";

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "aspose-cloud/aspose-words-cloud",
-            "version": "24.11.0",
+            "version": "24.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aspose-words-cloud/aspose-words-cloud-php.git",
-                "reference": "afbd5d76668105406abfd82d4d3120fa10334687"
+                "reference": "5d484b94878a3aa5efc4515276f52e507be2ea58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aspose-words-cloud/aspose-words-cloud-php/zipball/afbd5d76668105406abfd82d4d3120fa10334687",
-                "reference": "afbd5d76668105406abfd82d4d3120fa10334687",
+                "url": "https://api.github.com/repos/aspose-words-cloud/aspose-words-cloud-php/zipball/5d484b94878a3aa5efc4515276f52e507be2ea58",
+                "reference": "5d484b94878a3aa5efc4515276f52e507be2ea58",
                 "shasum": ""
             },
             "require": {
@@ -94,9 +94,9 @@
             ],
             "support": {
                 "issues": "https://github.com/aspose-words-cloud/aspose-words-cloud-php/issues",
-                "source": "https://github.com/aspose-words-cloud/aspose-words-cloud-php/tree/24.11.0"
+                "source": "https://github.com/aspose-words-cloud/aspose-words-cloud-php/tree/24.12.0"
             },
-            "time": "2024-11-20T07:18:07+00:00"
+            "time": "2024-12-10T09:10:22+00:00"
         },
         {
             "name": "aws/aws-crt-php",
@@ -154,16 +154,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.334.1",
+            "version": "3.334.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "3938b3467f64a30fed7ee1762a6785f808a5ae4d"
+                "reference": "3b4fa2180f5c6307c2d3c577392d3702d1f78eaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/3938b3467f64a30fed7ee1762a6785f808a5ae4d",
-                "reference": "3938b3467f64a30fed7ee1762a6785f808a5ae4d",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/3b4fa2180f5c6307c2d3c577392d3702d1f78eaf",
+                "reference": "3b4fa2180f5c6307c2d3c577392d3702d1f78eaf",
                 "shasum": ""
             },
             "require": {
@@ -246,9 +246,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.334.1"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.334.5"
             },
-            "time": "2024-12-05T01:17:41+00:00"
+            "time": "2024-12-12T19:25:15+00:00"
         },
         {
             "name": "brick/math",
@@ -1555,16 +1555,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v11.34.2",
+            "version": "v11.35.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "865da6d73dd353f07a7bcbd778c55966a620121f"
+                "reference": "dcfa130ede1a6fa4343dc113410963e791ad34fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/865da6d73dd353f07a7bcbd778c55966a620121f",
-                "reference": "865da6d73dd353f07a7bcbd778c55966a620121f",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/dcfa130ede1a6fa4343dc113410963e791ad34fb",
+                "reference": "dcfa130ede1a6fa4343dc113410963e791ad34fb",
                 "shasum": ""
             },
             "require": {
@@ -1588,6 +1588,7 @@
                 "league/commonmark": "^2.2.1",
                 "league/flysystem": "^3.25.1",
                 "league/flysystem-local": "^3.25.1",
+                "league/uri": "^7.5.1",
                 "monolog/monolog": "^3.0",
                 "nesbot/carbon": "^2.72.2|^3.4",
                 "nunomaduro/termwind": "^2.0",
@@ -1671,9 +1672,9 @@
                 "league/flysystem-read-only": "^3.25.1",
                 "league/flysystem-sftp-v3": "^3.25.1",
                 "mockery/mockery": "^1.6.10",
-                "nyholm/psr7": "^1.2",
                 "orchestra/testbench-core": "^9.6",
                 "pda/pheanstalk": "^5.0.6",
+                "php-http/discovery": "^1.15",
                 "phpstan/phpstan": "^1.11.5",
                 "phpunit/phpunit": "^10.5.35|^11.3.6",
                 "predis/predis": "^2.3",
@@ -1705,8 +1706,8 @@
                 "league/flysystem-read-only": "Required to use read-only disks (^3.25.1)",
                 "league/flysystem-sftp-v3": "Required to use the Flysystem SFTP driver (^3.25.1).",
                 "mockery/mockery": "Required to use mocking (^1.6).",
-                "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
                 "pda/pheanstalk": "Required to use the beanstalk queue driver (^5.0).",
+                "php-http/discovery": "Required to use PSR-7 bridging features (^1.15).",
                 "phpunit/phpunit": "Required to use assertions and run tests (^10.5|^11.0).",
                 "predis/predis": "Required to use the predis connector (^2.3).",
                 "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
@@ -1727,6 +1728,7 @@
             },
             "autoload": {
                 "files": [
+                    "src/Illuminate/Collections/functions.php",
                     "src/Illuminate/Collections/helpers.php",
                     "src/Illuminate/Events/functions.php",
                     "src/Illuminate/Filesystem/functions.php",
@@ -1764,7 +1766,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2024-11-27T15:43:57+00:00"
+            "time": "2024-12-12T18:25:58+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -1827,16 +1829,16 @@
         },
         {
             "name": "laravel/sanctum",
-            "version": "v4.0.5",
+            "version": "v4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sanctum.git",
-                "reference": "fe361b9a63407a228f884eb78d7217f680b50140"
+                "reference": "9e069e36d90b1e1f41886efa0fe9800a6b354694"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sanctum/zipball/fe361b9a63407a228f884eb78d7217f680b50140",
-                "reference": "fe361b9a63407a228f884eb78d7217f680b50140",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/9e069e36d90b1e1f41886efa0fe9800a6b354694",
+                "reference": "9e069e36d90b1e1f41886efa0fe9800a6b354694",
                 "shasum": ""
             },
             "require": {
@@ -1887,7 +1889,7 @@
                 "issues": "https://github.com/laravel/sanctum/issues",
                 "source": "https://github.com/laravel/sanctum"
             },
-            "time": "2024-11-26T14:36:23+00:00"
+            "time": "2024-11-26T21:18:33+00:00"
         },
         {
             "name": "laravel/serializable-closure",
@@ -2629,6 +2631,180 @@
                 }
             ],
             "time": "2024-09-21T08:32:55+00:00"
+        },
+        {
+            "name": "league/uri",
+            "version": "7.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri.git",
+                "reference": "81fb5145d2644324614cc532b28efd0215bda430"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/81fb5145d2644324614cc532b28efd0215bda430",
+                "reference": "81fb5145d2644324614cc532b28efd0215bda430",
+                "shasum": ""
+            },
+            "require": {
+                "league/uri-interfaces": "^7.5",
+                "php": "^8.1"
+            },
+            "conflict": {
+                "league/uri-schemes": "^1.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-fileinfo": "to create Data URI from file contennts",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "jeremykendall/php-domain-parser": "to resolve Public Suffix and Top Level Domain",
+                "league/uri-components": "Needed to easily manipulate URI objects components",
+                "php-64bit": "to improve IPV4 host parsing",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "middleware",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "uri",
+                "uri-template",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri/tree/7.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-12-08T08:40:02+00:00"
+        },
+        {
+            "name": "league/uri-interfaces",
+            "version": "7.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-interfaces.git",
+                "reference": "08cfc6c4f3d811584fb09c37e2849e6a7f9b0742"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/08cfc6c4f3d811584fb09c37e2849e6a7f9b0742",
+                "reference": "08cfc6c4f3d811584fb09c37e2849e6a7f9b0742",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^8.1",
+                "psr/http-factory": "^1",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "php-64bit": "to improve IPV4 host parsing",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "Common interfaces and classes for URI representation and interaction",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "uri",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-12-08T08:18:47+00:00"
         },
         {
             "name": "maennchen/zipstream-php",
@@ -3876,9 +4052,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-develop": "2.0-dev"
-                },
                 "laravel": {
                     "aliases": {
                         "JWTAuth": "PHPOpenSourceSaver\\JWTAuth\\Facades\\JWTAuth",
@@ -3887,6 +4060,9 @@
                     "providers": [
                         "PHPOpenSourceSaver\\JWTAuth\\Providers\\LaravelServiceProvider"
                     ]
+                },
+                "branch-alias": {
+                    "dev-develop": "2.0-dev"
                 }
             },
             "autoload": {
@@ -4110,16 +4286,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "1.29.5",
+            "version": "1.29.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "727cb704d5479fe4ddc291497ee471c4ec08f1b6"
+                "reference": "08597725b84570cd6f32bf0ea92e75a803ef28c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/727cb704d5479fe4ddc291497ee471c4ec08f1b6",
-                "reference": "727cb704d5479fe4ddc291497ee471c4ec08f1b6",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/08597725b84570cd6f32bf0ea92e75a803ef28c2",
+                "reference": "08597725b84570cd6f32bf0ea92e75a803ef28c2",
                 "shasum": ""
             },
             "require": {
@@ -4147,7 +4323,7 @@
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "dev-main",
-                "dompdf/dompdf": "^1.0 || ^2.0",
+                "dompdf/dompdf": "^1.0 || ^2.0 || ^3.0",
                 "friendsofphp/php-cs-fixer": "^3.2",
                 "mitoteam/jpgraph": "^10.3",
                 "mpdf/mpdf": "^8.1.1",
@@ -4209,9 +4385,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.29.5"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.29.6"
             },
-            "time": "2024-11-22T05:57:44+00:00"
+            "time": "2024-12-08T05:49:00+00:00"
         },
         {
             "name": "phpoffice/phpword",
@@ -4921,16 +5097,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.6",
+            "version": "v0.12.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "3b5ea0efaa791cd1c65ecc493aec3e2aa55ff57c"
+                "reference": "d73fa3c74918ef4522bb8a3bf9cab39161c4b57c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/3b5ea0efaa791cd1c65ecc493aec3e2aa55ff57c",
-                "reference": "3b5ea0efaa791cd1c65ecc493aec3e2aa55ff57c",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/d73fa3c74918ef4522bb8a3bf9cab39161c4b57c",
+                "reference": "d73fa3c74918ef4522bb8a3bf9cab39161c4b57c",
                 "shasum": ""
             },
             "require": {
@@ -4994,9 +5170,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.6"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.7"
             },
-            "time": "2024-12-07T20:08:52+00:00"
+            "time": "2024-12-10T01:58:33+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -5225,16 +5401,16 @@
         },
         {
             "name": "setasign/fpdi",
-            "version": "v2.6.1",
+            "version": "v2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Setasign/FPDI.git",
-                "reference": "09a816004fcee9ed3405bd164147e3fdbb79a56f"
+                "reference": "9e013b376939c0d4029f54150d2a16f3c67a5797"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Setasign/FPDI/zipball/09a816004fcee9ed3405bd164147e3fdbb79a56f",
-                "reference": "09a816004fcee9ed3405bd164147e3fdbb79a56f",
+                "url": "https://api.github.com/repos/Setasign/FPDI/zipball/9e013b376939c0d4029f54150d2a16f3c67a5797",
+                "reference": "9e013b376939c0d4029f54150d2a16f3c67a5797",
                 "shasum": ""
             },
             "require": {
@@ -5285,7 +5461,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Setasign/FPDI/issues",
-                "source": "https://github.com/Setasign/FPDI/tree/v2.6.1"
+                "source": "https://github.com/Setasign/FPDI/tree/v2.6.2"
             },
             "funding": [
                 {
@@ -5293,7 +5469,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-02T10:17:15+00:00"
+            "time": "2024-12-10T13:12:19+00:00"
         },
         {
             "name": "spatie/pdf-to-image",
@@ -5441,16 +5617,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.2.0",
+            "version": "v7.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "23c8aae6d764e2bae02d2a99f7532a7f6ed619cf"
+                "reference": "fefcc18c0f5d0efe3ab3152f15857298868dc2c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/23c8aae6d764e2bae02d2a99f7532a7f6ed619cf",
-                "reference": "23c8aae6d764e2bae02d2a99f7532a7f6ed619cf",
+                "url": "https://api.github.com/repos/symfony/console/zipball/fefcc18c0f5d0efe3ab3152f15857298868dc2c3",
+                "reference": "fefcc18c0f5d0efe3ab3152f15857298868dc2c3",
                 "shasum": ""
             },
             "require": {
@@ -5514,7 +5690,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.2.0"
+                "source": "https://github.com/symfony/console/tree/v7.2.1"
             },
             "funding": [
                 {
@@ -5530,7 +5706,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-06T14:24:19+00:00"
+            "time": "2024-12-11T03:49:26+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -5666,16 +5842,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.2.0",
+            "version": "v7.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "672b3dd1ef8b87119b446d67c58c106c43f965fe"
+                "reference": "6150b89186573046167796fa5f3f76601d5145f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/672b3dd1ef8b87119b446d67c58c106c43f965fe",
-                "reference": "672b3dd1ef8b87119b446d67c58c106c43f965fe",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/6150b89186573046167796fa5f3f76601d5145f8",
+                "reference": "6150b89186573046167796fa5f3f76601d5145f8",
                 "shasum": ""
             },
             "require": {
@@ -5721,7 +5897,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.2.0"
+                "source": "https://github.com/symfony/error-handler/tree/v7.2.1"
             },
             "funding": [
                 {
@@ -5737,7 +5913,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-05T15:35:02+00:00"
+            "time": "2024-12-07T08:50:44+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -6039,16 +6215,16 @@
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.2.0",
+            "version": "v7.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "6b4722a25e0aed1ccb4914b9bcbd493cc4676b4d"
+                "reference": "d8ae58eecae44c8e66833e76cc50a4ad3c002d97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/6b4722a25e0aed1ccb4914b9bcbd493cc4676b4d",
-                "reference": "6b4722a25e0aed1ccb4914b9bcbd493cc4676b4d",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/d8ae58eecae44c8e66833e76cc50a4ad3c002d97",
+                "reference": "d8ae58eecae44c8e66833e76cc50a4ad3c002d97",
                 "shasum": ""
             },
             "require": {
@@ -6133,7 +6309,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.2.0"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.2.1"
             },
             "funding": [
                 {
@@ -6149,7 +6325,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-29T08:42:40+00:00"
+            "time": "2024-12-11T12:09:10+00:00"
         },
         {
             "name": "symfony/mailer",
@@ -6233,16 +6409,16 @@
         },
         {
             "name": "symfony/mime",
-            "version": "v7.2.0",
+            "version": "v7.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "cc84a4b81f62158c3846ac7ff10f696aae2b524d"
+                "reference": "7f9617fcf15cb61be30f8b252695ed5e2bfac283"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/cc84a4b81f62158c3846ac7ff10f696aae2b524d",
-                "reference": "cc84a4b81f62158c3846ac7ff10f696aae2b524d",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/7f9617fcf15cb61be30f8b252695ed5e2bfac283",
+                "reference": "7f9617fcf15cb61be30f8b252695ed5e2bfac283",
                 "shasum": ""
             },
             "require": {
@@ -6297,7 +6473,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.2.0"
+                "source": "https://github.com/symfony/mime/tree/v7.2.1"
             },
             "funding": [
                 {
@@ -6313,7 +6489,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-23T09:19:39+00:00"
+            "time": "2024-12-07T08:50:44+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -6341,8 +6517,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -6417,8 +6593,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -6496,8 +6672,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -6578,8 +6754,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -6662,8 +6838,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -6804,8 +6980,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -6884,8 +7060,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -6966,8 +7142,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -8546,16 +8722,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "11.0.7",
+            "version": "11.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "f7f08030e8811582cc459871d28d6f5a1a4d35ca"
+                "reference": "418c59fd080954f8c4aa5631d9502ecda2387118"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f7f08030e8811582cc459871d28d6f5a1a4d35ca",
-                "reference": "f7f08030e8811582cc459871d28d6f5a1a4d35ca",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/418c59fd080954f8c4aa5631d9502ecda2387118",
+                "reference": "418c59fd080954f8c4aa5631d9502ecda2387118",
                 "shasum": ""
             },
             "require": {
@@ -8574,7 +8750,7 @@
                 "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.4.1"
+                "phpunit/phpunit": "^11.5.0"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -8612,7 +8788,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.7"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.8"
             },
             "funding": [
                 {
@@ -8620,7 +8796,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-09T06:21:38+00:00"
+            "time": "2024-12-11T12:34:27+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -8869,16 +9045,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.0",
+            "version": "11.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0569902506a6c0878930b87ea79ec3b50ea563f7"
+                "reference": "2b94d4f2450b9869fa64a46fd8a6a41997aef56a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0569902506a6c0878930b87ea79ec3b50ea563f7",
-                "reference": "0569902506a6c0878930b87ea79ec3b50ea563f7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2b94d4f2450b9869fa64a46fd8a6a41997aef56a",
+                "reference": "2b94d4f2450b9869fa64a46fd8a6a41997aef56a",
                 "shasum": ""
             },
             "require": {
@@ -8950,7 +9126,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.0"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.1"
             },
             "funding": [
                 {
@@ -8966,7 +9142,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-06T05:57:38+00:00"
+            "time": "2024-12-11T10:52:48+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -9027,23 +9203,23 @@
         },
         {
             "name": "sebastian/code-unit",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "6bb7d09d6623567178cf54126afa9c2310114268"
+                "reference": "ee88b0cdbe74cf8dd3b54940ff17643c0d6543ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/6bb7d09d6623567178cf54126afa9c2310114268",
-                "reference": "6bb7d09d6623567178cf54126afa9c2310114268",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/ee88b0cdbe74cf8dd3b54940ff17643c0d6543ca",
+                "reference": "ee88b0cdbe74cf8dd3b54940ff17643c0d6543ca",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^11.5"
             },
             "type": "library",
             "extra": {
@@ -9072,7 +9248,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
                 "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.2"
             },
             "funding": [
                 {
@@ -9080,7 +9256,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T04:44:28+00:00"
+            "time": "2024-12-12T09:59:06+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",


### PR DESCRIPTION
Before Condtion:
In some condition, when count pdf files by using $pdf->pageCount() with spatiePDF modules. It'll run issue in some of PDF files when it can't repopulate with Ghostscript and return error;

`PDFDelegateFailed [ghostscript library 10.04] -sstdout=%stderr -dQUIET -dSAFER -dBATCH -dNOPAUSE -dNOPROMPT -dMaxBitmap=500000000 -dAlignToPixels=0 -dGridFitTT=2 '-sDEVICE=pngalpha' -dTextAlphaBits=4 -dGraphicsAlphaBits=4 '-r2.0x2.0' -dPrinted=false  '-sOutputFile=/tmp/magick-eLtRTJYemQEHIfT1hu3Tuv42uBnodDfK%d' '-f/tmp/magick-Coayb8omrqMkD5YVdcNfHgbCobmeJmeK' '-f/tmp/magick-gjttaXChInmMeYFp5Fq7DgXYBefCiceK': (null)' @ error/pdf.c/ReadPDFImage/712`

The backend itself doesn't crash, cause error already handled properly. But it'll be stopper to main process due fail to get total PDF pages.

Next Condition:
Use old php native function to count PDF pages from previous method, to count properly PDF pages in the mean time
