### PR TITLE
[HOTFIX][BE]: Make sure URL always use HTTPS

### DIFF
--- a/app/Http/Controllers/Api/Core/htmltopdfController.php
+++ b/app/Http/Controllers/Api/Core/htmltopdfController.php
@@ -104,14 +104,14 @@ class htmltopdfController extends Controller
                 'procDuration' => null
             ]);
             if (AppHelper::Instance()->checkWebAvailable($pdfUrl)) {
-                $newUrl = $pdfUrl;
+                $newUrl = 'https://'.$pdfUrl;
             } else {
                 if (AppHelper::Instance()->checkWebAvailable('https://'.$pdfUrl)) {
                     $newUrl = 'https://'.$pdfUrl;
                 } else if (AppHelper::Instance()->checkWebAvailable('http://'.$pdfUrl)) {
-                    $newUrl = 'http://'.$pdfUrl;
+                    $newUrl = 'https://'.$pdfUrl;
                 } else if (AppHelper::Instance()->checkWebAvailable('www.'.$pdfUrl)) {
-                    $newUrl = 'www.'.$pdfUrl;
+                    $newUrl = 'https://'.$pdfUrl;
                 } else {
                     $end = Carbon::parse(AppHelper::instance()->getCurrentTimeZone());
                     $duration = $end->diff($startProc);

--- a/app/Http/Controllers/Api/Misc/versionController.php
+++ b/app/Http/Controllers/Api/Misc/versionController.php
@@ -43,7 +43,7 @@ class versionController extends Controller {
             $appServicesReferrerFE = $request->post('appServicesReferrer');
             $appMajorVersionBE = 3;
             $appMinorVersionBE = 8;
-            $appPatchVersionBE = 0;
+            $appPatchVersionBE = 1;
             $appVersioningBE = null;
             $appVersioningFE = null;
             $appServicesReferrerBE = "BE";

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,12 @@
 {
     "$schema": "https://getcomposer.org/schema.json",
-    "name": "laravel/laravel",
+    "name": "hana-ci/hana-pdf",
     "type": "project",
-    "description": "The skeleton application for the Laravel framework.",
+    "description": "Laravel Project: Easily and quickly merge, split, compress, convert, and add watermarks to PDF documents",
     "keywords": [
         "laravel",
-        "framework"
+        "framework",
+        "iLovePDF"
     ],
     "license": "MIT",
     "require": {


### PR DESCRIPTION
# What's changed
- [Api: Core: HtmlToPDF: Make sure URL always return with HTTPS](https://github.com/Nicklas373/Hana-PDF/commit/9b910829b961fadbacdcc78e8176429456a61be2)

Story:
We need to satisfied external API requirements when send URL to HTMLToPDF process (iLoveAPI), after doing dirty hack on previous patch. It seems they only want to proceed HTTPS and somehow reject other values like http or www. So hardcoded URL from our BE with addition only HTTPS before send to iLoveAPI